### PR TITLE
i18n: translation to Simplified Chinese

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -259,7 +259,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "（顶级）"
+            "value" : "（顶层）"
           }
         }
       }
@@ -919,7 +919,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 毫秒"
+            "value" : "%lld ms"
           }
         }
       }
@@ -1389,7 +1389,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "2024-08/视频/IMG_2020.MOV"
+            "value" : "2024-08/Video/IMG_2020.MOV"
           }
         }
       }
@@ -1469,7 +1469,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "2024/08/11/视频/IMG_2020.MOV"
+            "value" : "2024/08/11/Video/IMG_2020.MOV"
           }
         }
       }
@@ -1629,7 +1629,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "2024/视频/IMG_2020.MOV"
+            "value" : "2024/Video/IMG_2020.MOV"
           }
         }
       }
@@ -1749,7 +1749,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关于Synctrain"
+            "value" : "关于 Synctrain"
           }
         }
       }
@@ -2109,7 +2109,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "添加专辑"
+            "value" : "添加相册"
           }
         }
       }
@@ -2893,7 +2893,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld小时后"
+            "value" : "%lld 小时后"
           }
         }
       }
@@ -3053,7 +3053,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未找到专辑"
+            "value" : "未找到相册"
           }
         }
       }
@@ -3373,7 +3373,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "允许Synctrain访问照片"
+            "value" : "允许 Synctrain 访问照片"
           }
         }
       }
@@ -12279,7 +12279,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "来自专辑"
+            "value" : "来自相册"
           }
         }
       }
@@ -28939,7 +28939,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "视频/IMG_2020.MOV"
+            "value" : "Video/IMG_2020.MOV"
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -55,6 +55,12 @@
             "state" : "translated",
             "value" : "Синхронізація файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件同步已启动"
+          }
         }
       }
     },
@@ -88,6 +94,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Синхронізація файлів завершена"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-"
           }
         }
       }
@@ -123,6 +135,12 @@
             "state" : "translated",
             "value" : "(Місце за замовчуванням)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（默认位置）"
+          }
         }
       }
     },
@@ -156,6 +174,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "(Папку не вибрано)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（未选择文件夹）"
           }
         }
       }
@@ -191,6 +215,12 @@
             "state" : "translated",
             "value" : "(Немає)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在同步…"
+          }
         }
       }
     },
@@ -225,6 +255,12 @@
             "state" : "translated",
             "value" : "(Верхній рівень)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（顶级）"
+          }
         }
       }
     },
@@ -255,6 +291,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
@@ -299,6 +341,12 @@
             "state" : "translated",
             "value" : "%@ (%@)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (%@)"
+          }
         }
       }
     },
@@ -332,6 +380,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ має всі файли, які хоче"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已拥有所需的所有文件"
           }
         }
       }
@@ -369,6 +423,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: %@"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@: %@"
@@ -413,6 +473,12 @@
             "state" : "translated",
             "value" : "%@/%@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@/%@"
+          }
         }
       }
     },
@@ -447,6 +513,12 @@
             "state" : "translated",
             "value" : "%@/с"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@/s"
+          }
         }
       }
     },
@@ -477,6 +549,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -532,6 +610,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld файлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个文件"
           }
         }
       }
@@ -595,6 +679,12 @@
             "state" : "translated",
             "value" : "%lld файлів і %lld підкаталогів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个文件和 %lld 个子目录"
+          }
         }
       }
     },
@@ -646,6 +736,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld файлів вибрано"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择 %lld 个文件"
           }
         }
       }
@@ -699,6 +795,12 @@
             "state" : "translated",
             "value" : "%lld елементів вибрано"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择 %lld 项"
+          }
         }
       }
     },
@@ -732,6 +834,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld МБ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld MB"
           }
         }
       }
@@ -767,6 +875,12 @@
             "state" : "translated",
             "value" : "%lld Мбіт/с"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Mbit/s"
+          }
         }
       }
     },
@@ -800,6 +914,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld мс"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 毫秒"
           }
         }
       }
@@ -841,6 +961,12 @@
             "state" : "translated",
             "value" : "%lld з %lld"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld的%lld"
+          }
         }
       }
     },
@@ -874,6 +1000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld вибрано"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 已选择"
           }
         }
       }
@@ -927,6 +1059,12 @@
             "state" : "translated",
             "value" : "%lld підкаталоги"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 个子目录"
+          }
         }
       }
     },
@@ -967,6 +1105,12 @@
             "state" : "translated",
             "value" : "%lld з %lld"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld"
+          }
         }
       }
     },
@@ -997,6 +1141,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld%%"
@@ -1035,6 +1185,12 @@
             "state" : "translated",
             "value" : "0.0.0.0"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0.0.0.0"
+          }
         }
       }
     },
@@ -1065,6 +1221,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024-08-11_IMG_2020.MOV"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2024-08-11_IMG_2020.MOV"
@@ -1103,6 +1265,12 @@
             "state" : "translated",
             "value" : "2024-08-11/IMG_2020.HEIC"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024-08-11/IMG_2020.HEIC"
+          }
         }
       }
     },
@@ -1133,6 +1301,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024-08-11/Video/IMG_2020.MOV"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2024-08-11/Video/IMG_2020.MOV"
@@ -1171,6 +1345,12 @@
             "state" : "translated",
             "value" : "2024-08/IMG_2020.HEIC"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024-08/IMG_2020.HEIC"
+          }
         }
       }
     },
@@ -1205,6 +1385,12 @@
             "state" : "translated",
             "value" : "2024-08/Video/IMG_2020.MOV"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024-08/视频/IMG_2020.MOV"
+          }
         }
       }
     },
@@ -1235,6 +1421,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024/08/11/IMG_2020.HEIC"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2024/08/11/IMG_2020.HEIC"
@@ -1273,6 +1465,12 @@
             "state" : "translated",
             "value" : "2024/08/11/Відео/IMG_2020.MOV"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024/08/11/视频/IMG_2020.MOV"
+          }
         }
       }
     },
@@ -1303,6 +1501,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024/08/IMG_2020.HEIC"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2024/08/IMG_2020.HEIC"
@@ -1341,6 +1545,12 @@
             "state" : "translated",
             "value" : "2024/08/Video/IMG_2020.MOV"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024/08/Video/IMG_2020.MOV"
+          }
         }
       }
     },
@@ -1371,6 +1581,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024/IMG_2020.MOV"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "2024/IMG_2020.MOV"
@@ -1409,6 +1625,12 @@
             "state" : "translated",
             "value" : "2024/Video/IMG_2020.MOV"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2024/视频/IMG_2020.MOV"
+          }
         }
       }
     },
@@ -1439,6 +1661,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "22000"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "22000"
@@ -1477,6 +1705,12 @@
             "state" : "translated",
             "value" : "Залишається спадкова база даних. Якщо застосунок працює правильно, цю базу даних можна безпечно видалити вручну. Для цього необхідно перезапустити застосунок."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍然存在旧数据库。如果应用程序正常运行，可以安全地手动删除此数据库。为此需要重新启动应用程序。"
+          }
         }
       }
     },
@@ -1510,6 +1744,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Про Synctrain"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于Synctrain"
           }
         }
       }
@@ -1545,6 +1785,12 @@
             "state" : "translated",
             "value" : "Про цей додаток"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于这个应用"
+          }
         }
       }
     },
@@ -1578,6 +1824,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Про..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于..."
           }
         }
       }
@@ -1613,6 +1865,12 @@
             "state" : "translated",
             "value" : "Доступ до цієї сторінки заборонено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此页面的访问被拒绝"
+          }
         }
       }
     },
@@ -1646,6 +1904,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Токен доступу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "访问令牌"
           }
         }
       }
@@ -1681,6 +1945,12 @@
             "state" : "translated",
             "value" : "Дія"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
         }
       }
     },
@@ -1714,6 +1984,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дії"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
           }
         }
       }
@@ -1749,6 +2025,12 @@
             "state" : "translated",
             "value" : "Додати"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
+          }
         }
       }
     },
@@ -1782,6 +2064,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додати адресу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加地址"
           }
         }
       }
@@ -1817,6 +2105,12 @@
             "state" : "translated",
             "value" : "Додати альбом"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加专辑"
+          }
         }
       }
     },
@@ -1850,6 +2144,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додати альбом..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加相册..."
           }
         }
       }
@@ -1885,6 +2185,12 @@
             "state" : "translated",
             "value" : "Додати пристрій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加设备"
+          }
         }
       }
     },
@@ -1918,6 +2224,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додати пристрій..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加设备..."
           }
         }
       }
@@ -1953,6 +2265,12 @@
             "state" : "translated",
             "value" : "Додати папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加文件夹"
+          }
         }
       }
     },
@@ -1986,6 +2304,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додати папку..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加文件夹..."
           }
         }
       }
@@ -2021,6 +2345,12 @@
             "state" : "translated",
             "value" : "Додати рядок"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加行"
+          }
         }
       }
     },
@@ -2054,6 +2384,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додати до альбому"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加到相册"
           }
         }
       }
@@ -2089,6 +2425,12 @@
             "state" : "translated",
             "value" : "Додайте свій перший пристрій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加您的首个设备"
+          }
         }
       }
     },
@@ -2122,6 +2464,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додайте свою першу папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加您的第一个文件夹"
           }
         }
       }
@@ -2157,6 +2505,12 @@
             "state" : "translated",
             "value" : "Додані пристрої можуть за власною ініціативою підключатися до цього пристрою, поки додаток працює. Це може призвести до додаткового розряду батареї. Рекомендується вмикати цю функцію лише у разі труднощів з підключенням до інших пристроїв."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加的设备可以在应用运行时主动连接到此设备。这可能会导致额外的电池消耗。建议仅在连接其他设备遇到困难时启用此功能。"
+          }
         }
       }
     },
@@ -2190,6 +2544,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додавання папки з іншого додатка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从其他应用添加文件夹"
           }
         }
       }
@@ -2225,6 +2585,12 @@
             "state" : "translated",
             "value" : "Додаткові адреси"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "额外地址"
+          }
         }
       }
     },
@@ -2258,6 +2624,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тип адреси"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地址类型"
           }
         }
       }
@@ -2293,6 +2665,12 @@
             "state" : "translated",
             "value" : "Адреси"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地址"
+          }
         }
       }
     },
@@ -2326,6 +2704,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розширені"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高级"
           }
         }
       }
@@ -2361,6 +2745,12 @@
             "state" : "translated",
             "value" : "Розширені налаштування папки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高级文件夹设置"
+          }
         }
       }
     },
@@ -2394,6 +2784,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розширені налаштування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高级设置"
           }
         }
       }
@@ -2441,6 +2837,12 @@
             "state" : "translated",
             "value" : "Через %lld днів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %lld 天后"
+          }
         }
       }
     },
@@ -2487,6 +2889,12 @@
             "state" : "translated",
             "value" : "Через %lld годин"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld小时后"
+          }
         }
       }
     },
@@ -2520,6 +2928,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Після оновлення бази даних копія старої версії зберігається деякий час. Ця копія може займати значний обсяг пам'яті. Якщо все працює так, як очікується, цей резервний екземпляр можна безпечно видалити."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在数据库升级后，会保留旧版本的副本一段时间。这个副本可能会占用大量存储空间。如果一切正常工作，可以安全地删除此备份。"
           }
         }
       }
@@ -2555,6 +2969,12 @@
             "state" : "translated",
             "value" : "Після перезапуску додатка, він створить файл журналу в папці програми, яким ви зможете поділитися з розробниками."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新启动应用后，应用会在应用文件夹中写入一个日志文件，然后您可以与开发者共享该文件。"
+          }
         }
       }
     },
@@ -2588,6 +3008,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Після збереження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存后"
           }
         }
       }
@@ -2623,6 +3049,12 @@
             "state" : "translated",
             "value" : "альбом не знайдено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到专辑"
+          }
         }
       }
     },
@@ -2656,6 +3088,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Альбоми"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相册"
           }
         }
       }
@@ -2691,6 +3129,12 @@
             "state" : "translated",
             "value" : "Усі пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有设备"
+          }
         }
       }
     },
@@ -2724,6 +3168,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Усі пристрої призупинено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有设备已暂停"
           }
         }
       }
@@ -2759,6 +3209,12 @@
             "state" : "translated",
             "value" : "Всі файли"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有文件"
+          }
         }
       }
     },
@@ -2792,6 +3248,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Усі файли у папці буде скопійовано на цей пристрій."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹中的所有文件将复制到此设备。"
           }
         }
       }
@@ -2827,6 +3289,12 @@
             "state" : "translated",
             "value" : "Всі файли, включаючи ті, які недоступні в інших місцях"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有文件，包括其他地方不可用的文件"
+          }
         }
       }
     },
@@ -2860,6 +3328,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Усі файли, доступні на інших пристроях"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在其他设备上可用的所有文件"
           }
         }
       }
@@ -2895,6 +3369,12 @@
             "state" : "translated",
             "value" : "Дозволити Synctrain доступ до фотографій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许Synctrain访问照片"
+          }
         }
       }
     },
@@ -2928,6 +3408,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Також обмежте в локальних мережах"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在本地网络中也限制"
           }
         }
       }
@@ -2963,6 +3449,12 @@
             "state" : "translated",
             "value" : "Зашифрована версія папки ділиться з цим пристроєм."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该设备共享了加密版本的文件夹。"
+          }
         }
       }
     },
@@ -2996,6 +3488,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сталася помилка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发生了错误"
           }
         }
       }
@@ -3031,6 +3529,12 @@
             "state" : "translated",
             "value" : "На сервері сталася помилка (%lld)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器发生错误（%lld）"
+          }
         }
       }
     },
@@ -3064,6 +3568,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сталася помилка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发生错误"
           }
         }
       }
@@ -3099,6 +3609,12 @@
             "state" : "translated",
             "value" : "Оголосити глобально"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全球公告"
+          }
         }
       }
     },
@@ -3132,6 +3648,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Оголосити адреси LAN"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公告局域网地址"
           }
         }
       }
@@ -3167,6 +3689,12 @@
             "state" : "translated",
             "value" : "Оголосити в локальних мережах"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在本地网络上宣布"
+          }
         }
       }
     },
@@ -3200,6 +3728,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додаток"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用"
           }
         }
       }
@@ -3235,6 +3769,12 @@
             "state" : "translated",
             "value" : "Застосувати"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用"
+          }
         }
       }
     },
@@ -3268,6 +3808,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Застосувати та очистити папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用并清理文件夹"
           }
         }
       }
@@ -3303,6 +3849,12 @@
             "state" : "translated",
             "value" : "Застосувати шаблони та очистити папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用模式并清理文件夹"
+          }
         }
       }
     },
@@ -3337,6 +3889,12 @@
             "state" : "translated",
             "value" : "Ви впевнені, що хочете застосувати шаблони та очистити папку? Файли та підкаталоги, що відповідають шаблонам, будуть назавжди видалені з цього пристрою. Файли можуть бути втрачені, якщо вони недоступні на інших пристроях."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要应用这些模式并清理文件夹吗？与模式匹配的文件和子目录将从此设备中永久删除。如果文件在其他设备上不可用，可能会丢失。"
+          }
         }
       }
     },
@@ -3370,6 +3928,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ви впевнені, що хочете очистити кеш ескізів?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要清除缩略图缓存吗？"
           }
         }
       }
@@ -3439,6 +4003,12 @@
             "state" : "translated",
             "value" : "Ви впевнені, що хочете назавжди видалити %lld файлів з цього пристрою та додати %lld файлів для синхронізації з іншими пристроями?"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要从此设备永久删除 %lld 个文件，并添加 %lld 个文件以与其他设备同步吗？"
+          }
         }
       }
     },
@@ -3472,6 +4042,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ви впевнені, що хочете видалити цей файл з усіх пристроїв?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要从所有设备中删除此文件吗？"
           }
         }
       }
@@ -3507,6 +4083,12 @@
             "state" : "translated",
             "value" : "Ви впевнені, що хочете видалити цей файл з усіх пристроїв? Локальна копія цього файлу - єдина, яка зараз доступна на будь-якому з пристроїв. Це видалить останню копію. Відновити файл після видалення буде неможливо."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要从所有设备中删除此文件吗？此文件的本地副本是当前唯一在任何设备上可用的。这将删除最后一个副本。删除后将无法恢复此文件。"
+          }
         }
       }
     },
@@ -3540,6 +4122,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ви впевнені, що хочете видалити цю папку? Будь ласка, обміркуйте це ретельно. Усі файли в цій папці будуть видалені з цього пристрою. Файли, що ще не синхронізовані з іншими пристроями, не можуть бути відновлені."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要删除此文件夹吗？请仔细考虑。此文件夹中的所有文件都将从此设备中删除。尚未同步到其他设备的文件将无法恢复。"
           }
         }
       }
@@ -3575,6 +4163,12 @@
             "state" : "translated",
             "value" : "Ви впевнені, що хочете від'єднати обрані пристрої?"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要取消链接所选设备吗？"
+          }
         }
       }
     },
@@ -3608,6 +4202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ви впевнені, що хочете від'єднати цю папку? Папка більше не буде синхронізуватись. Файли, що наразі на цьому пристрої, не будуть видалені."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您确定要取消链接此文件夹吗？该文件夹将不再同步。当前设备上的文件不会被删除。"
           }
         }
       }
@@ -3643,6 +4243,12 @@
             "state" : "translated",
             "value" : "Задайте питання"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提出问题"
+          }
         }
       }
     },
@@ -3676,6 +4282,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пов'язані пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关联设备"
           }
         }
       }
@@ -3711,6 +4323,12 @@
             "state" : "translated",
             "value" : "Автоматично відображати веб-сторінки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动显示网页"
+          }
         }
       }
     },
@@ -3744,6 +4362,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Автоматично перемкнути на вигляд сітки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动切换到网格视图"
           }
         }
       }
@@ -3779,6 +4403,12 @@
             "state" : "translated",
             "value" : "Резервне копіювання нових фото"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "备份新照片"
+          }
         }
       }
     },
@@ -3812,6 +4442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Фонове синхронізування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "后台同步"
           }
         }
       }
@@ -3847,6 +4483,12 @@
             "state" : "translated",
             "value" : "Фонову синхронізацію завершено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "后台同步完成"
+          }
         }
       }
     },
@@ -3880,6 +4522,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Фонову синхронізацію було виконано понад %lld годин тому. Відкрийте додаток для синхронізації."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "后台同步在 %lld 小时前最后一次运行。打开应用程序以进行同步。"
           }
         }
       }
@@ -3915,6 +4563,12 @@
             "state" : "translated",
             "value" : "Фонове синхронізація тривала %lld секунд"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "后台同步运行了 %lld 秒"
+          }
         }
       }
     },
@@ -3948,6 +4602,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пропускна здатність"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "带宽"
           }
         }
       }
@@ -3983,6 +4643,12 @@
             "state" : "translated",
             "value" : "Обмеження пропускної здатності"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "带宽限制"
+          }
         }
       }
     },
@@ -4016,6 +4682,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Основний"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基本"
           }
         }
       }
@@ -4051,6 +4723,12 @@
             "state" : "translated",
             "value" : "Через налаштування нижче, яке передбачає негайне видалення фото після збереження, новозбережені фото не будуть додаватися до цього альбому."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由于下面的设置在保存后立即删除照片，新保存的照片将不会添加到此相册中。"
+          }
         }
       }
     },
@@ -4084,6 +4762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перш ніж почати, нам потрібно обговорити кілька речей:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在开始之前，我们需要先了解一些事情："
           }
         }
       }
@@ -4119,6 +4803,12 @@
             "state" : "translated",
             "value" : "Незабаром після виходу з додатка"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离开应用后不久"
+          }
         }
       }
     },
@@ -4152,6 +4842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Від %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由%@提供"
           }
         }
       }
@@ -4187,6 +4883,12 @@
             "state" : "translated",
             "value" : "Цим пристроєм"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过此设备"
+          }
         }
       }
     },
@@ -4220,6 +4922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кеш у папці"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缓存到文件夹"
           }
         }
       }
@@ -4255,6 +4963,12 @@
             "state" : "translated",
             "value" : "Розташування кешу"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缓存位置"
+          }
         }
       }
     },
@@ -4288,6 +5002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кеш на цьому пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的缓存"
           }
         }
       }
@@ -4323,6 +5043,12 @@
             "state" : "translated",
             "value" : "Кешувати мініатюри на диску"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在磁盘上缓存缩略图"
+          }
         }
       }
     },
@@ -4356,6 +5082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Скасувати"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
           }
         }
       }
@@ -4391,6 +5123,12 @@
             "state" : "translated",
             "value" : "Не вдалося знайти вибрану папку з ID '%@'"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法找到具有ID“%@”的选定文件夹"
+          }
         }
       }
     },
@@ -4424,6 +5162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неможливо переглянути цей файл"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法预览此文件"
           }
         }
       }
@@ -4459,6 +5203,12 @@
             "state" : "translated",
             "value" : "Не вдалося відобразити попередній перегляд для цього типу файлу."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法为此类型的文件显示预览。"
+          }
         }
       }
     },
@@ -4492,6 +5242,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдається відобразити цю сторінку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法显示此页面"
           }
         }
       }
@@ -4527,6 +5283,12 @@
             "state" : "translated",
             "value" : "Не вдалося запустити додаток"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法启动应用程序"
+          }
         }
       }
     },
@@ -4560,6 +5322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Змінити видимість"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改可见性"
           }
         }
       }
@@ -4595,6 +5363,12 @@
             "state" : "translated",
             "value" : "Змінено о"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改于"
+          }
         }
       }
     },
@@ -4628,6 +5402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Змінено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改者"
           }
         }
       }
@@ -4663,6 +5443,12 @@
             "state" : "translated",
             "value" : "Перевірка доступності на інших пристроях..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查其他设备上的可用性..."
+          }
         }
       }
     },
@@ -4696,6 +5482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очищення..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清理中..."
           }
         }
       }
@@ -4731,6 +5523,12 @@
             "state" : "translated",
             "value" : "Очистити кеш мініатюр"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除缩略图缓存"
+          }
         }
       }
     },
@@ -4764,6 +5562,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрити"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
           }
         }
       }
@@ -4799,6 +5603,12 @@
             "state" : "translated",
             "value" : "Закрити програму"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭应用"
+          }
         }
       }
     },
@@ -4832,6 +5642,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завершення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
@@ -4867,6 +5683,12 @@
             "state" : "translated",
             "value" : "Папку конфігурації змінено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置文件夹已更改"
+          }
         }
       }
     },
@@ -4900,6 +5722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Місцезнаходження папки конфігурації"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置文件夹位置"
           }
         }
       }
@@ -4935,6 +5763,12 @@
             "state" : "translated",
             "value" : "Налаштування конфігурації"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置设置"
+          }
         }
       }
     },
@@ -4968,6 +5802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштувати пристрій(ї)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置设备"
           }
         }
       }
@@ -5003,6 +5843,12 @@
             "state" : "translated",
             "value" : "Налаштувати папку(и)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置文件夹"
+          }
         }
       }
     },
@@ -5036,6 +5882,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Конфліктуючі версії цього файлу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件的冲突版本"
           }
         }
       }
@@ -5071,6 +5923,12 @@
             "state" : "translated",
             "value" : "Підключено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已连接"
+          }
         }
       }
     },
@@ -5104,6 +5962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Підключення до інших пристроїв може ініціювати лише цей пристрій, а не інші додані пристрої."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接其他设备只能由此设备发起，而不能由其他添加的设备发起。"
           }
         }
       }
@@ -5139,6 +6003,12 @@
             "state" : "translated",
             "value" : "Підключення"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接性"
+          }
         }
       }
     },
@@ -5172,6 +6042,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Продовжити"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续"
           }
         }
       }
@@ -5207,6 +6083,12 @@
             "state" : "translated",
             "value" : "Копіювати"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制"
+          }
         }
       }
     },
@@ -5240,6 +6122,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Скопіювати зовнішнє посилання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制外部链接"
           }
         }
       }
@@ -5275,6 +6163,12 @@
             "state" : "translated",
             "value" : "Копіювати фото"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制照片"
+          }
         }
       }
     },
@@ -5308,6 +6202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Копіювати фотографії періодично у фоновому режимі"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "定期在后台复制照片"
           }
         }
       }
@@ -5343,6 +6243,12 @@
             "state" : "translated",
             "value" : "Копіювати в буфер обміну"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制到剪贴板"
+          }
         }
       }
     },
@@ -5376,6 +6282,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося додати пристрій"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法添加设备"
           }
         }
       }
@@ -5411,6 +6323,12 @@
             "state" : "translated",
             "value" : "Не вдалося додати папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法添加文件夹"
+          }
         }
       }
     },
@@ -5444,6 +6362,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося змінити адреси"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法更改地址"
           }
         }
       }
@@ -5479,6 +6403,12 @@
             "state" : "translated",
             "value" : "Не вдалося змінити налаштування синхронізації"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法更改同步设置"
+          }
         }
       }
     },
@@ -5512,6 +6442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося розшифрувати папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法解密文件夹"
           }
         }
       }
@@ -5547,6 +6483,12 @@
             "state" : "translated",
             "value" : "Не вдалося визначити доступність файлу: %@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法确定文件的可用性：%@"
+          }
         }
       }
     },
@@ -5580,6 +6522,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося завантажити файл"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法下载文件"
           }
         }
       }
@@ -5615,6 +6563,12 @@
             "state" : "translated",
             "value" : "Не вдалося знайти вибраний альбом"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法找到所选相册"
+          }
         }
       }
     },
@@ -5648,6 +6602,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося повторно підключити папку: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法重新链接文件夹：%@"
           }
         }
       }
@@ -5683,6 +6643,12 @@
             "state" : "translated",
             "value" : "Не вдалося повторно зв'язати папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法重新链接文件夹"
+          }
         }
       }
     },
@@ -5716,6 +6682,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося встановити ключ шифрування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法设置加密密钥"
           }
         }
       }
@@ -5751,6 +6723,12 @@
             "state" : "translated",
             "value" : "Не вдалося запустити програму: %@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法启动应用：%@"
+          }
         }
       }
     },
@@ -5784,6 +6762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося переглянути файл"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法查看文件"
           }
         }
       }
@@ -5819,6 +6803,12 @@
             "state" : "translated",
             "value" : "Поточний"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前"
+          }
         }
       }
     },
@@ -5852,6 +6842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поточні адреси"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前地址"
           }
         }
       }
@@ -5887,6 +6883,12 @@
             "state" : "translated",
             "value" : "Наразі файли з інших пристроїв не завантажуються."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前没有从其他设备下载文件。"
+          }
         }
       }
     },
@@ -5920,6 +6922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зараз жодні файли не відправляються на інші пристрої."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前没有文件发送到其他设备。"
           }
         }
       }
@@ -5955,6 +6963,12 @@
             "state" : "translated",
             "value" : "Пошук за кількома критеріями наразі не підтримується, якщо не потрібно виконувати всі критерії."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前不支持使用多个条件进行搜索，除非所有条件都是必需的。"
+          }
         }
       }
     },
@@ -5988,6 +7002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зараз кеш ескізів використовує %@ дискового простору."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前缩略图缓存使用了 %@ 的磁盘空间。"
           }
         }
       }
@@ -6023,6 +7043,12 @@
             "state" : "translated",
             "value" : "Виявлено власну конфігурацію"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检测到自定义配置"
+          }
         }
       }
     },
@@ -6056,6 +7082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування користувача збережено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义配置已保存"
           }
         }
       }
@@ -6091,6 +7123,12 @@
             "state" : "translated",
             "value" : "Обслуговування бази даних"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据库维护"
+          }
         }
       }
     },
@@ -6124,6 +7162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тип бази даних"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数据库类型"
           }
         }
       }
@@ -6159,6 +7203,12 @@
             "state" : "translated",
             "value" : "Дата"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期"
+          }
         }
       }
     },
@@ -6192,6 +7242,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дата/Тип"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期/类型"
           }
         }
       }
@@ -6227,6 +7283,12 @@
             "state" : "translated",
             "value" : "Розшифрувати %lld файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密 %lld 个文件"
+          }
         }
       }
     },
@@ -6260,6 +7322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розшифрувати теку..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密文件夹..."
           }
         }
       }
@@ -6295,6 +7363,12 @@
             "state" : "translated",
             "value" : "Розшифрувати список файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密文件列表"
+          }
         }
       }
     },
@@ -6328,6 +7402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розшифрувати папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密文件夹"
           }
         }
       }
@@ -6363,6 +7443,12 @@
             "state" : "translated",
             "value" : "Розшифрований шлях"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密路径"
+          }
         }
       }
     },
@@ -6396,6 +7482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розшифрування завершено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解密完成"
           }
         }
       }
@@ -6431,6 +7523,12 @@
             "state" : "translated",
             "value" : "Затримка під час обробки змін (секунди)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "处理更改的延迟（秒）"
+          }
         }
       }
     },
@@ -6464,6 +7562,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
           }
         }
       }
@@ -6559,6 +7663,12 @@
             "state" : "translated",
             "value" : "Видалити %lld файлів, залишити %lld файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除 %lld 个文件，保留 %lld 个文件"
+          }
         }
       }
     },
@@ -6592,6 +7702,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити файл"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除文件"
           }
         }
       }
@@ -6627,6 +7743,12 @@
             "state" : "translated",
             "value" : "Видалити ескізи"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除缩略图"
+          }
         }
       }
     },
@@ -6660,6 +7782,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зняти вибір файлів, які знаходяться на інших пристроях"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消选择其他设备上的文件"
           }
         }
       }
@@ -6695,6 +7823,12 @@
             "state" : "translated",
             "value" : "Пристрій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备"
+          }
         }
       }
     },
@@ -6728,6 +7862,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Адреси пристроїв"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备地址"
           }
         }
       }
@@ -6763,6 +7903,12 @@
             "state" : "translated",
             "value" : "Ідентифікатор пристрою"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备ID"
+          }
         }
       }
     },
@@ -6796,6 +7942,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ідентифікатор пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备标识符"
           }
         }
       }
@@ -6831,6 +7983,12 @@
             "state" : "translated",
             "value" : "Інформація про пристрій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备信息"
+          }
         }
       }
     },
@@ -6864,6 +8022,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Назва пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备名称"
           }
         }
       }
@@ -6899,6 +8063,12 @@
             "state" : "translated",
             "value" : "Налаштування пристрою"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备设置"
+          }
         }
       }
     },
@@ -6932,6 +8102,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备"
           }
         }
       }
@@ -6967,6 +8143,12 @@
             "state" : "translated",
             "value" : "Пристрої, що потребують вашої уваги"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要您关注的设备"
+          }
         }
       }
     },
@@ -7000,6 +8182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Напрямок"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方向"
           }
         }
       }
@@ -7035,6 +8223,12 @@
             "state" : "translated",
             "value" : "Вимкнути"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用"
+          }
         }
       }
     },
@@ -7068,6 +8262,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вимкнення «cлідкуйте за змінами» для цієї папки може вирішити проблему."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用此文件夹的“监视更改”功能可能会解决此问题。"
           }
         }
       }
@@ -7103,6 +8303,12 @@
             "state" : "translated",
             "value" : "Виявлені пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发现的设备"
+          }
         }
       }
     },
@@ -7136,6 +8342,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Виявлені папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已发现的文件夹"
           }
         }
       }
@@ -7171,6 +8383,12 @@
             "state" : "translated",
             "value" : "Відкриття"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发现"
+          }
         }
       }
     },
@@ -7204,6 +8422,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відхилити"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
           }
         }
       }
@@ -7239,6 +8463,12 @@
             "state" : "translated",
             "value" : "Відображуване ім'я"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示名称"
+          }
         }
       }
     },
@@ -7272,6 +8502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не кешувати"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不缓存"
           }
         }
       }
@@ -7307,6 +8543,12 @@
             "state" : "translated",
             "value" : "Не змінювати"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不要更改"
+          }
         }
       }
     },
@@ -7340,6 +8582,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не зберігати фотографії, старіші ніж шість місяців"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不要保存超过六个月的照片"
           }
         }
       }
@@ -7375,6 +8623,12 @@
             "state" : "translated",
             "value" : "Не показувати папки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不显示文件夹"
+          }
         }
       }
     },
@@ -7408,6 +8662,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не синхронізувати з цим пристроєм"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不要与此设备同步"
           }
         }
       }
@@ -7443,6 +8703,12 @@
             "state" : "translated",
             "value" : "Готово"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
+          }
         }
       }
     },
@@ -7476,6 +8742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завантажити файли"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载文件"
           }
         }
       }
@@ -7511,6 +8783,12 @@
             "state" : "translated",
             "value" : "Завантажено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已下载"
+          }
         }
       }
     },
@@ -7544,6 +8822,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Завантаження файлу..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在下载文件..."
           }
         }
       }
@@ -7579,6 +8863,12 @@
             "state" : "translated",
             "value" : "Тривалість"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "持续时间"
+          }
         }
       }
     },
@@ -7612,6 +8902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Протягом останніх 24 годин (%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在过去的24小时内（%@）"
           }
         }
       }
@@ -7647,6 +8943,12 @@
             "state" : "translated",
             "value" : "Увімкнути"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用"
+          }
         }
       }
     },
@@ -7680,6 +8982,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Увімкнути журнал налагодження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用调试日志"
           }
         }
       }
@@ -7715,6 +9023,12 @@
             "state" : "translated",
             "value" : "Увімкнути NAT-PMP / UPnP"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用 NAT-PMP / UPnP"
+          }
         }
       }
     },
@@ -7748,6 +9062,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Увімкнути сповіщення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用通知"
           }
         }
       }
@@ -7783,6 +9103,12 @@
             "state" : "translated",
             "value" : "Увімкнути реле"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用中继"
+          }
         }
       }
     },
@@ -7816,6 +9142,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Увімкнути STUN"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用STUN"
           }
         }
       }
@@ -7851,6 +9183,12 @@
             "state" : "translated",
             "value" : "Увімкнути синхронізацію"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用同步"
+          }
         }
       }
     },
@@ -7884,6 +9222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Увімкнено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已启用"
           }
         }
       }
@@ -7919,6 +9263,12 @@
             "state" : "translated",
             "value" : "Зашифровано"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已加密"
+          }
         }
       }
     },
@@ -7952,6 +9302,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зашифрований шлях до файлу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密文件路径"
           }
         }
       }
@@ -7987,6 +9343,12 @@
             "state" : "translated",
             "value" : "URL зашифрованих файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密文件的 URL"
+          }
         }
       }
     },
@@ -8020,6 +9382,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зашифрована папка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密文件夹"
           }
         }
       }
@@ -8055,6 +9423,12 @@
             "state" : "translated",
             "value" : "Зашифровані посилання для спільного доступу"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密共享链接"
+          }
         }
       }
     },
@@ -8088,6 +9462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Деталі шифрування..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密详情..."
           }
         }
       }
@@ -8123,6 +9503,12 @@
             "state" : "translated",
             "value" : "Пароль шифрування"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加密密码"
+          }
         }
       }
     },
@@ -8156,6 +9542,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ліцензійна угода з кінцевим користувачем"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最终用户许可协议"
           }
         }
       }
@@ -8191,6 +9583,12 @@
             "state" : "translated",
             "value" : "Завершено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已结束"
+          }
         }
       }
     },
@@ -8224,6 +9622,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введіть текст для пошуку в поле пошуку вище."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在上方的搜索字段中输入文本以进行搜索。"
           }
         }
       }
@@ -8259,6 +9663,12 @@
             "state" : "translated",
             "value" : "Помилка"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "错误"
+          }
         }
       }
     },
@@ -8292,6 +9702,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Помилка завантаження налаштувань ігнорування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加载忽略设置时出错"
           }
         }
       }
@@ -8327,6 +9743,12 @@
             "state" : "translated",
             "value" : "Приклад розташування файлу в папці:"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件在文件夹中的示例位置："
+          }
         }
       }
     },
@@ -8360,6 +9782,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Існуюча папка: '%@'"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "现有文件夹：'%@'"
           }
         }
       }
@@ -8395,6 +9823,12 @@
             "state" : "translated",
             "value" : "Існуюча папка..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "现有文件夹..."
+          }
         }
       }
     },
@@ -8428,6 +9862,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Переглянути вміст архіву"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览存档内容"
           }
         }
       }
@@ -8463,6 +9903,12 @@
             "state" : "translated",
             "value" : "Переглянути вміст архіву..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览档案内容..."
+          }
         }
       }
     },
@@ -8496,6 +9942,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Експортувати файл конфігурації"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出配置文件"
           }
         }
       }
@@ -8531,6 +9983,12 @@
             "state" : "translated",
             "value" : "Зовнішня папка"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部文件夹"
+          }
         }
       }
     },
@@ -8564,6 +10022,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зовнішнє спільне використання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部共享"
           }
         }
       }
@@ -8599,6 +10063,12 @@
             "state" : "translated",
             "value" : "Знайдено додаткові файли. Оскільки це папка тільки для отримання, ці файли не будуть синхронізовані."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发现了额外的文件。由于这是一个仅接收文件夹，这些文件将不会被同步。"
+          }
         }
       }
     },
@@ -8632,6 +10102,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Знайдено додаткові файли. Будь ласка, вирішіть для кожного файлу, чи слід його синхронізувати або видалити."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发现了额外的文件。请决定每个文件是同步还是删除。"
           }
         }
       }
@@ -8667,6 +10143,12 @@
             "state" : "translated",
             "value" : "Додаткові файли в папці %@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹 %@ 中的额外文件"
+          }
         }
       }
     },
@@ -8700,6 +10182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вдалося: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失败：%@"
           }
         }
       }
@@ -8735,6 +10223,12 @@
             "state" : "translated",
             "value" : "Файл"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件"
+          }
         }
       }
     },
@@ -8768,6 +10262,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ключ шифрування файлу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件加密密钥"
           }
         }
       }
@@ -8803,6 +10303,12 @@
             "state" : "translated",
             "value" : "Операції з файлами"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件处理"
+          }
         }
       }
     },
@@ -8836,6 +10342,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ім'я файлу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件名"
           }
         }
       }
@@ -8871,6 +10383,12 @@
             "state" : "translated",
             "value" : "Файл на цьому пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的文件"
+          }
         }
       }
     },
@@ -8904,6 +10422,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перегляди файлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件预览"
           }
         }
       }
@@ -8939,6 +10463,12 @@
             "state" : "translated",
             "value" : "Розмір файлу"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件大小"
+          }
         }
       }
     },
@@ -8972,6 +10502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тип файлу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件类型"
           }
         }
       }
@@ -9007,6 +10543,12 @@
             "state" : "translated",
             "value" : "Файл видалено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件已删除"
+          }
         }
       }
     },
@@ -9040,6 +10582,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файл/папка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件/文件夹"
           }
         }
       }
@@ -9075,6 +10623,12 @@
             "state" : "translated",
             "value" : "Файли"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件"
+          }
         }
       }
     },
@@ -9108,6 +10662,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файли та підкаталоги, шляхи яких збігаються з будь-яким із наведених вище шаблонів, не будуть синхронізовані з іншими пристроями. Існуючі елементи, що відповідають шаблонам, не будуть оновлюватися."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路径与上述模式匹配的文件和子目录将不会与其他设备同步。与模式匹配的现有项目将不会更新。"
           }
         }
       }
@@ -9143,6 +10703,12 @@
             "state" : "translated",
             "value" : "Файли в '%@' збережено на цьому пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储在此设备上的“%@”中的文件"
+          }
         }
       }
     },
@@ -9176,6 +10742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файли зберігаються на пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件保存在设备上"
           }
         }
       }
@@ -9211,6 +10783,12 @@
             "state" : "translated",
             "value" : "Файли збережено на цьому пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件保存在此设备上"
+          }
         }
       }
     },
@@ -9244,6 +10822,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файли збережено на цьому пристрої у '%@'"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件保存在本设备的“%@”中"
           }
         }
       }
@@ -9279,6 +10863,12 @@
             "state" : "translated",
             "value" : "Файли, збережені на цьому пристрої..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存在此设备上的文件..."
+          }
         }
       }
     },
@@ -9312,6 +10902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файли потрібні від %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所需文件由 %@"
           }
         }
       }
@@ -9347,6 +10943,12 @@
             "state" : "translated",
             "value" : "Файли, необхідні для цього пристрою"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备所需的文件"
+          }
         }
       }
     },
@@ -9380,6 +10982,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файли на цьому пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的文件"
           }
         }
       }
@@ -9415,6 +11023,12 @@
             "state" : "translated",
             "value" : "Файли для ігнорування"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略的文件"
+          }
         }
       }
     },
@@ -9448,6 +11062,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файли для ігнорування..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要忽略的文件..."
           }
         }
       }
@@ -9483,6 +11103,12 @@
             "state" : "translated",
             "value" : "Відбиток пальця"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指纹"
+          }
         }
       }
     },
@@ -9517,6 +11143,12 @@
             "state" : "translated",
             "value" : "Завершено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
+          }
         }
       }
     },
@@ -9550,6 +11182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹"
           }
         }
       }
@@ -9591,6 +11229,12 @@
             "state" : "translated",
             "value" : "Папка '%@' має проблему: %@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹“%@”有问题：%@"
+          }
         }
       }
     },
@@ -9624,6 +11268,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка '%@' містить додаткові файли"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹“%@”有额外文件"
           }
         }
       }
@@ -9659,6 +11309,12 @@
             "state" : "translated",
             "value" : "Папка '%@' більше не доступна"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹“%@”已无法访问"
+          }
         }
       }
     },
@@ -9692,6 +11348,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Доступ до папки з меню"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从菜单访问文件夹"
           }
         }
       }
@@ -9727,6 +11389,12 @@
             "state" : "translated",
             "value" : "Дії з папками"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹操作"
+          }
         }
       }
     },
@@ -9760,6 +11428,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка не існує"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹不存在"
           }
         }
       }
@@ -9795,6 +11469,12 @@
             "state" : "translated",
             "value" : "Пароль шифрування папки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹加密密码"
+          }
         }
       }
     },
@@ -9828,6 +11508,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ID папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹 ID"
           }
         }
       }
@@ -9863,6 +11549,12 @@
             "state" : "translated",
             "value" : "Папку видалено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹已移除"
+          }
         }
       }
     },
@@ -9896,6 +11588,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹设置"
           }
         }
       }
@@ -9931,6 +11629,12 @@
             "state" : "translated",
             "value" : "Налаштування папки..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹设置..."
+          }
         }
       }
     },
@@ -9964,6 +11668,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Статистика папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹统计"
           }
         }
       }
@@ -9999,6 +11709,12 @@
             "state" : "translated",
             "value" : "Статистика папки: '%@'"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹统计：“%@”"
+          }
         }
       }
     },
@@ -10032,6 +11748,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Статистика папок..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹统计..."
           }
         }
       }
@@ -10067,6 +11789,12 @@
             "state" : "translated",
             "value" : "Структура папок"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹结构"
+          }
         }
       }
     },
@@ -10100,6 +11828,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка для зняття вибору файлів."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用于取消选择文件的文件夹。"
           }
         }
       }
@@ -10135,6 +11869,12 @@
             "state" : "translated",
             "value" : "Папка для видалення порожніх незсинхронізованих підкаталогів. Папка має бути вибірково синхронізована."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用于删除空的未同步子目录的文件夹。文件夹必须选择性同步。"
+          }
         }
       }
     },
@@ -10168,6 +11908,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка занадто велика для стеження"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹太大，无法监视"
           }
         }
       }
@@ -10203,6 +11949,12 @@
             "state" : "translated",
             "value" : "Тип папки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹类型"
+          }
         }
       }
     },
@@ -10236,6 +11988,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папку було видалено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹已删除"
           }
         }
       }
@@ -10271,6 +12029,12 @@
             "state" : "translated",
             "value" : "Папки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹"
+          }
         }
       }
     },
@@ -10304,6 +12068,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папки, які потребують вашої уваги"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要您关注的文件夹"
           }
         }
       }
@@ -10345,6 +12115,12 @@
             "state" : "translated",
             "value" : "Для файлу в цій теці за розташуванням '%@', згенероване посилання для спільного доступу буде %@'. Щоб посилання дійсно працювало, потрібно налаштувати веб-сервер, який буде обслуговувати теку за вказаною URL-адресою."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "对于位于位置“%@”的此文件夹内的文件，生成的共享链接将为 %@'。要使链接实际工作，您需要设置一个网络服务器，在指定的 URL 提供此文件夹服务。"
+          }
         }
       }
     },
@@ -10378,6 +12154,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Для всіх файлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "针对所有文件"
           }
         }
       }
@@ -10413,6 +12195,12 @@
             "state" : "translated",
             "value" : "Звільнити місце"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "腾出空间"
+          }
         }
       }
     },
@@ -10446,6 +12234,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Часті запитання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常见问题"
           }
         }
       }
@@ -10481,6 +12275,12 @@
             "state" : "translated",
             "value" : "З альбому"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "来自专辑"
+          }
         }
       }
     },
@@ -10514,6 +12314,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Повна папка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整文件夹"
           }
         }
       }
@@ -10549,6 +12355,12 @@
             "state" : "translated",
             "value" : "Загальний"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常规"
+          }
         }
       }
     },
@@ -10582,6 +12394,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Створити мініатюри"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成缩略图"
           }
         }
       }
@@ -10617,6 +12435,12 @@
             "state" : "translated",
             "value" : "Згенеровані URL будуть виглядати як '%@'. Вам потрібно налаштувати веб-сервер та/або додаток для обробки цих URL."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成的URL将类似于'%@'。您需要配置一个Web服务器和/或应用程序来处理这些URL。"
+          }
         }
       }
     },
@@ -10650,6 +12474,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Генерація ескізів може зайняти деякий час і використовувати багато даних. Рекомендується підключитися до мережі Wi-Fi перед продовженням. Ви впевнені, що хочете продовжити?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成缩略图可能需要一些时间，且可能使用大量数据。建议在继续之前连接到 Wi-Fi 网络。您确定要继续吗？"
           }
         }
       }
@@ -10691,6 +12521,12 @@
             "state" : "translated",
             "value" : "Створення ескізів... (%lld / %lld)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在生成缩略图... (%lld / %lld)"
+          }
         }
       }
     },
@@ -10724,6 +12560,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отримати ідентифікатор пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取设备ID"
           }
         }
       }
@@ -10759,6 +12601,12 @@
             "state" : "translated",
             "value" : "Отримати дані про зашифрований файл"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取加密文件详情"
+          }
         }
       }
     },
@@ -10792,6 +12640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отримати файли у папці, які потрібні іншому пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取文件夹中其他设备所需的文件"
           }
         }
       }
@@ -10827,6 +12681,12 @@
             "state" : "translated",
             "value" : "Отримати файли у папці, які необхідні цьому пристрою"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取此设备所需文件夹中的文件"
+          }
         }
       }
     },
@@ -10860,6 +12720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отримати каталог папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取文件夹目录"
           }
         }
       }
@@ -10895,6 +12761,12 @@
             "state" : "translated",
             "value" : "Отримати нові, несинхронізовані файли в папці"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取文件夹中未同步的新文件"
+          }
         }
       }
     },
@@ -10928,6 +12800,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Початок"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始使用"
           }
         }
       }
@@ -10963,6 +12841,12 @@
             "state" : "translated",
             "value" : "Глобальні сервери оголошень"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全局公告服务器"
+          }
         }
       }
     },
@@ -10997,6 +12881,12 @@
             "state" : "translated",
             "value" : "Глобальні сервери анонсів..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全局公告服务器..."
+          }
         }
       }
     },
@@ -11027,6 +12917,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GMT"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "GMT"
@@ -11065,6 +12961,12 @@
             "state" : "translated",
             "value" : "Перейти до каталогу '%@'"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "转到目录“%@”"
+          }
         }
       }
     },
@@ -11098,6 +13000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перейти до розташування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往位置"
           }
         }
       }
@@ -11133,6 +13041,12 @@
             "state" : "translated",
             "value" : "Перейдіть до програми Налаштування, щоб дозволити сповіщення."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往“设置”应用允许通知。"
+          }
         }
       }
     },
@@ -11166,6 +13080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сітка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网格"
           }
         }
       }
@@ -11201,6 +13121,12 @@
             "state" : "translated",
             "value" : "Сітка з попередніми переглядами"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网格预览"
+          }
         }
       }
     },
@@ -11234,6 +13160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сітка з попередніми переглядами"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏"
           }
         }
       }
@@ -11269,6 +13201,12 @@
             "state" : "translated",
             "value" : "Приховати значок док-меню"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏Dock菜单图标"
+          }
         }
       }
     },
@@ -11302,6 +13240,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Приховати системні файли"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏点文件"
           }
         }
       }
@@ -11337,6 +13281,12 @@
             "state" : "translated",
             "value" : "Приховати приховані папки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏隐藏文件夹"
+          }
         }
       }
     },
@@ -11370,6 +13320,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Приховати в док-меню"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏到 Dock"
           }
         }
       }
@@ -11405,6 +13361,12 @@
             "state" : "translated",
             "value" : "Приховати у додатку «Файли»"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在文件应用中隐藏"
+          }
         }
       }
     },
@@ -11438,6 +13400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ім'я хоста"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主机名"
           }
         }
       }
@@ -11473,6 +13441,12 @@
             "state" : "translated",
             "value" : "Скільки секунд загалом чекати, щоб пристрої стали доступними для завантаження, перш ніж здатися (секунди)."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备下载可用前放弃的等待总时间（秒）。"
+          }
         }
       }
     },
@@ -11507,6 +13481,12 @@
             "state" : "translated",
             "value" : "Скільки часу виділити на синхронізацію."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允许同步的时间。"
+          }
         }
       }
     },
@@ -11537,6 +13517,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "HTTP"
@@ -11575,6 +13561,12 @@
             "state" : "translated",
             "value" : "HTTP-помилка %lld"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTP错误 %lld"
+          }
         }
       }
     },
@@ -11605,6 +13597,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTTPS"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "HTTPS"
@@ -11643,6 +13641,12 @@
             "state" : "translated",
             "value" : "Я розумію і погоджуюсь"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我理解并同意"
+          }
         }
       }
     },
@@ -11676,6 +13680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Я розумію, давайте почнемо!"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我明白了，我们开始吧！"
           }
         }
       }
@@ -11711,6 +13721,12 @@
             "state" : "translated",
             "value" : "Якщо пристрій не ввімкнено, синхронізація з цим пристроєм зупинена."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果设备未启用，则与该设备的同步将暂停。"
+          }
         }
       }
     },
@@ -11744,6 +13760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Якщо пристрій не є довіреним, шифрувальний пароль вимагається для кожної папки, синхронізованої з пристроєм."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果设备不受信任，则每个与该设备同步的文件夹都需要加密密码。"
           }
         }
       }
@@ -11779,6 +13801,12 @@
             "state" : "translated",
             "value" : "Якщо це несподіванка, переконайтеся, що інші пристрої погодилися синхронізувати цю папку з вашим пристроєм."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果这是意外情况，请确保其他设备已接受将此文件夹与您的设备同步。"
+          }
         }
       }
     },
@@ -11812,6 +13840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Якщо ви видалите фотографії з папки, це буде запам'ятовано на шість місяців, тому вони не будуть знову збережені в папці протягом цього часу. Увімкніть це налаштування, щоб запобігти повторному експорту цих фотографій через шість місяців."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果您从文件夹中删除照片，这将在六个月内被记住，因此在此期间它们不会再次保存到文件夹中。启用此设置以防止这些照片在六个月后再次导出。"
           }
         }
       }
@@ -11847,6 +13881,12 @@
             "state" : "translated",
             "value" : "Якщо залишити поле пароля порожнім, файли на іншому пристрої не будуть зашифровані, і, таким чином, їх зможе прочитати будь-хто, у кого є доступ до іншого пристрою. Якщо ви встановите пароль шифрування, переконайтеся, що всі пристрої, які синхронізують ту ж папку з іншим пристроєм, використовують однаковий пароль."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果您将密码留空，文件在另一台设备上将不会被加密，因此任何有权访问另一台设备的人都可以读取这些文件。如果您设置加密密码，请确保所有与另一台设备同步相同文件夹的设备均使用相同的密码。"
+          }
         }
       }
     },
@@ -11880,6 +13920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ігнорувати певні системні файли"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略某些系统文件"
           }
         }
       }
@@ -11915,6 +13961,12 @@
             "state" : "translated",
             "value" : "Ігнорувати шаблони"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略模式"
+          }
         }
       }
     },
@@ -11945,6 +13997,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IMG_2020.MOV"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "IMG_2020.MOV"
@@ -11983,6 +14041,12 @@
             "state" : "translated",
             "value" : "Негайно"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即"
+          }
         }
       }
     },
@@ -12016,6 +14080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Недоступна зовнішня папка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法访问的外部文件夹"
           }
         }
       }
@@ -12051,6 +14121,12 @@
             "state" : "translated",
             "value" : "Недоступна папка"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法访问的文件夹"
+          }
         }
       }
     },
@@ -12084,6 +14160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Включити в резервну копію пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "包含在设备备份中"
           }
         }
       }
@@ -12119,6 +14201,12 @@
             "state" : "translated",
             "value" : "Недостатньо вільного місця для зберігання"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储空间不足"
+          }
         }
       }
     },
@@ -12152,6 +14240,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Недостатньо місця для зберігання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储空间不足"
           }
         }
       }
@@ -12187,6 +14281,12 @@
             "state" : "translated",
             "value" : "Запроваджено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由...介绍"
+          }
         }
       }
     },
@@ -12220,6 +14320,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пристрій для введення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介绍"
           }
         }
       }
@@ -12255,6 +14361,12 @@
             "state" : "translated",
             "value" : "некоректна конфігурація"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无效配置"
+          }
         }
       }
     },
@@ -12288,6 +14400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "IP-адреса або ім'я хоста"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IP地址或主机名"
           }
         }
       }
@@ -12323,6 +14441,12 @@
             "state" : "translated",
             "value" : "Це каталог"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是目录"
+          }
         }
       }
     },
@@ -12356,6 +14480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Є символьним посиланням"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是符号链接"
           }
         }
       }
@@ -12391,6 +14521,12 @@
             "state" : "translated",
             "value" : "Не є надійним"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不受信任"
+          }
         }
       }
     },
@@ -12424,6 +14560,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Залишити конфліктні версії"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留冲突版本"
           }
         }
       }
@@ -12459,6 +14601,12 @@
             "state" : "translated",
             "value" : "Зберегти файл"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留文件"
+          }
         }
       }
     },
@@ -12492,6 +14640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Остання адреса"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最后地址"
           }
         }
       }
@@ -12527,6 +14681,12 @@
             "state" : "translated",
             "value" : "Остання фонове синхронізація"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最后一次后台同步"
+          }
         }
       }
     },
@@ -12560,6 +14720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Останнє завершення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次完成"
           }
         }
       }
@@ -12595,6 +14761,12 @@
             "state" : "translated",
             "value" : "Останнє завершення %@."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最后完成于%@"
+          }
         }
       }
     },
@@ -12628,6 +14800,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Остання зміна"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次修改"
           }
         }
       }
@@ -12663,6 +14841,12 @@
             "state" : "translated",
             "value" : "Останнє редагування від"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最后修改自"
+          }
         }
       }
     },
@@ -12696,6 +14880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Останнє відвідування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次查看"
           }
         }
       }
@@ -12731,6 +14921,12 @@
             "state" : "translated",
             "value" : "Затримка"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "延迟"
+          }
         }
       }
     },
@@ -12764,6 +14960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Юридичні повідомлення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "法律声明"
           }
         }
       }
@@ -12799,6 +15001,12 @@
             "state" : "translated",
             "value" : "Обмежити ширину каналу передачі файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限制文件传输带宽"
+          }
         }
       }
     },
@@ -12832,6 +15040,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Обмежити пропускну здатність прийому"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限制接收带宽"
           }
         }
       }
@@ -12867,6 +15081,12 @@
             "state" : "translated",
             "value" : "Обмежити пропускну здатність відправлення"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限制发送带宽"
+          }
         }
       }
     },
@@ -12900,6 +15120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Обмежити потокове передавання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限制流播放"
           }
         }
       }
@@ -12935,6 +15161,12 @@
             "state" : "translated",
             "value" : "Обмежити пропускну здатність потокового передачі"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "限制流媒体带宽"
+          }
         }
       }
     },
@@ -12968,6 +15200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Місце призначення посилання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "链接目标"
           }
         }
       }
@@ -13003,6 +15241,12 @@
             "state" : "translated",
             "value" : "Тип посилання"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "链接类型"
+          }
         }
       }
     },
@@ -13033,6 +15277,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linkthing"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Linkthing"
@@ -13071,6 +15321,12 @@
             "state" : "translated",
             "value" : "Список"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列表"
+          }
         }
       }
     },
@@ -13104,6 +15360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Список з переглядами"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列表预览"
           }
         }
       }
@@ -13139,6 +15401,12 @@
             "state" : "translated",
             "value" : "Очікування вхідних з'єднань"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "监听传入连接"
+          }
         }
       }
     },
@@ -13172,6 +15440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Адреси прослуховування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "监听地址"
           }
         }
       }
@@ -13207,6 +15481,12 @@
             "state" : "translated",
             "value" : "Адреси прослуховування..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "监听地址..."
+          }
         }
       }
     },
@@ -13240,6 +15520,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Живі фото"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实况照片"
           }
         }
       }
@@ -13275,6 +15561,12 @@
             "state" : "translated",
             "value" : "Місцезнаходження"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位置"
+          }
         }
       }
     },
@@ -13308,6 +15600,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Логування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录"
           }
         }
       }
@@ -13343,6 +15641,12 @@
             "state" : "translated",
             "value" : "Журналювання уповільнює роботу додатка та використовує більше заряду батареї. Увімкніть його тільки у разі виникнення проблем."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日志记录会减慢应用程序的速度并消耗更多电量。只有在你遇到问题时才启用它。"
+          }
         }
       }
     },
@@ -13376,6 +15680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Логотип"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标志"
           }
         }
       }
@@ -13411,6 +15721,12 @@
             "state" : "translated",
             "value" : "Керування файлами та папками"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "管理文件和文件夹"
+          }
         }
       }
     },
@@ -13444,6 +15760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальний час очікування (секунди)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大等待时间（秒）"
           }
         }
       }
@@ -13479,6 +15801,12 @@
             "state" : "translated",
             "value" : "медіафайл наразі недоступний"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "媒体文件当前不可用"
+          }
         }
       }
     },
@@ -13512,6 +15840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Меню"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "菜单"
           }
         }
       }
@@ -13547,6 +15881,12 @@
             "state" : "translated",
             "value" : "Мінімальна кількість пристроїв, що повинні мати копію, перед тим як файл може бути десинхронізований."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件可以取消同步之前需要拥有副本的最小设备数量。"
+          }
         }
       }
     },
@@ -13580,6 +15920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Назва"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "姓名"
           }
         }
       }
@@ -13615,6 +15961,12 @@
             "state" : "translated",
             "value" : "Проходження мережі"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网络遍历"
+          }
         }
       }
     },
@@ -13648,6 +16000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ніколи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从不"
           }
         }
       }
@@ -13683,6 +16041,12 @@
             "state" : "translated",
             "value" : "Далі"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一步"
+          }
         }
       }
     },
@@ -13716,6 +16080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ще не додано жодного пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还没有添加设备"
           }
         }
       }
@@ -13751,6 +16121,12 @@
             "state" : "translated",
             "value" : "Не вибрано зашифровану папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择加密文件夹"
+          }
         }
       }
     },
@@ -13784,6 +16160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Немає додаткових файлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到额外文件"
           }
         }
       }
@@ -13819,6 +16201,12 @@
             "state" : "translated",
             "value" : "Файли не знайдено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到文件"
+          }
         }
       }
     },
@@ -13852,6 +16240,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не вибрано файлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择文件"
           }
         }
       }
@@ -13887,6 +16281,12 @@
             "state" : "translated",
             "value" : "Не визначено шаблони ігнорування"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未定义忽略模式"
+          }
         }
       }
     },
@@ -13920,6 +16320,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Немає"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无"
           }
         }
       }
@@ -13955,6 +16361,12 @@
             "state" : "translated",
             "value" : "Не підключено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未连接"
+          }
         }
       }
     },
@@ -13988,6 +16400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не завантажується"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未下载"
           }
         }
       }
@@ -14023,6 +16441,12 @@
             "state" : "translated",
             "value" : "Не розпочато"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未开始"
+          }
         }
       }
     },
@@ -14056,6 +16480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не завантажується"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未上传"
           }
         }
       }
@@ -14091,6 +16521,12 @@
             "state" : "translated",
             "value" : "Сповіщення"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知"
+          }
         }
       }
     },
@@ -14124,6 +16560,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кількість директорій"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目录数量"
           }
         }
       }
@@ -14159,6 +16601,12 @@
             "state" : "translated",
             "value" : "Кількість файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件数量"
+          }
         }
       }
     },
@@ -14192,6 +16640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отримати вихідний код"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取源代码"
           }
         }
       }
@@ -14227,6 +16681,12 @@
             "state" : "translated",
             "value" : "Отримайте зміни у вихідному коді"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获取源代码修改"
+          }
         }
       }
     },
@@ -14260,6 +16720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вимкнути"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
           }
         }
       }
@@ -14295,6 +16761,12 @@
             "state" : "translated",
             "value" : "OK"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好的"
+          }
         }
       }
     },
@@ -14328,6 +16800,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Увімкнено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开启"
           }
         }
       }
@@ -14363,6 +16841,12 @@
             "state" : "translated",
             "value" : "На цьому пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此设备上"
+          }
         }
       }
     },
@@ -14396,6 +16880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "На цьому пристрої: %lld%% від усієї папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此设备上：%lld%%的完整文件夹"
           }
         }
       }
@@ -14431,6 +16921,12 @@
             "state" : "translated",
             "value" : "Одного з'єднання достатньо"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一个连接就够了"
+          }
         }
       }
     },
@@ -14464,6 +16960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тільки копіювати"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅复制"
           }
         }
       }
@@ -14499,6 +17001,12 @@
             "state" : "translated",
             "value" : "Лише файли, які ви виберете, будуть скопійовані на цей пристрій. Ви все ще можете отримати доступ до всіх файлів у папці на вимогу, коли під'єднані до інших пристроїв, які мають копію файлу."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只有您选择的文件会被复制到此设备。您仍然可以在连接到具有该文件副本的其他设备时按需访问文件夹中的所有文件。"
+          }
         }
       }
     },
@@ -14532,6 +17040,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відкрити файловий браузер..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开文件浏览器..."
           }
         }
       }
@@ -14567,6 +17081,12 @@
             "state" : "translated",
             "value" : "Відкрити у додатку Файли"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在文件应用中打开"
+          }
         }
       }
     },
@@ -14600,6 +17120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відкрити у Finder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在访达中打开"
           }
         }
       }
@@ -14635,6 +17161,12 @@
             "state" : "translated",
             "value" : "Відкрити у Finder, крім вибірково синхронізованих папок"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Finder 中打开，除选择性同步的文件夹外"
+          }
         }
       }
     },
@@ -14668,6 +17200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відкрити у новому вікні"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在新窗口中打开"
           }
         }
       }
@@ -14703,6 +17241,12 @@
             "state" : "translated",
             "value" : "Відкрити в Safari"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在Safari中打开"
+          }
         }
       }
     },
@@ -14736,6 +17280,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відкрити в застосунку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在应用中打开"
           }
         }
       }
@@ -14771,6 +17321,12 @@
             "state" : "translated",
             "value" : "Відкритий код"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开源"
+          }
         }
       }
     },
@@ -14804,6 +17360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Компоненти з відкритим кодом"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开源组件"
           }
         }
       }
@@ -14839,6 +17401,12 @@
             "state" : "translated",
             "value" : "Відкрити за допомогою '%@'"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用 \"%@\" 打开"
+          }
         }
       }
     },
@@ -14872,6 +17440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Прогрес на інших пристроях"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他设备进度"
           }
         }
       }
@@ -14907,6 +17481,12 @@
             "state" : "translated",
             "value" : "Пароль"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密码"
+          }
         }
       }
     },
@@ -14940,6 +17520,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Шлях у папці"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹中的路径"
           }
         }
       }
@@ -14975,6 +17561,12 @@
             "state" : "translated",
             "value" : "Шаблон..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模式..."
+          }
         }
       }
     },
@@ -15008,6 +17600,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відсоток на пристрої"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备上的百分比"
           }
         }
       }
@@ -15043,6 +17641,12 @@
             "state" : "translated",
             "value" : "Резервне копіювання фото"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "照片备份"
+          }
         }
       }
     },
@@ -15076,6 +17680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка з фотографіями"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "照片文件夹"
           }
         }
       }
@@ -15111,6 +17721,12 @@
             "state" : "translated",
             "value" : "Папки з фотографіями можуть бути лише для відправки і не можуть бути синхронізовані вибірково."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "照片文件夹只能设为仅发送，无法选择性同步。"
+          }
         }
       }
     },
@@ -15144,6 +17760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папки з фотографіями можуть синхронізувати лише фотографії в поточній версії додатка. Щоб зберегти відео та/або живі фотографії, скористайтеся функцією резервного копіювання фото, доступною в екрані налаштувань."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前版本的应用程序中的照片文件夹只能同步照片。要保存视频和/或实况照片，请使用设置屏幕中的照片备份功能。"
           }
         }
       }
@@ -15179,6 +17801,12 @@
             "state" : "translated",
             "value" : "Фото"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "照片"
+          }
         }
       }
     },
@@ -15212,6 +17840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Фотографії з вибраного альбому будуть збережені у вибраній папці, в підпапках за датою створення. Якщо фотографія з таким самим ім'ям файлу вже існує у папці або була раніше видалена з папки, вона не буде збережена знову."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所选相册中的照片将保存到所选文件夹中，按创建日期分在子文件夹中。如果文件夹中已存在具有相同文件名的照片，或者已从文件夹中删除过，则不会再次保存。"
           }
         }
       }
@@ -15247,6 +17881,12 @@
             "state" : "translated",
             "value" : "Синхронізація фотографій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "照片同步"
+          }
         }
       }
     },
@@ -15280,6 +17920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Фотографії будуть видалені лише тоді, коли резервне копіювання фотографій буде розпочато вручну зсередини додатка, оскільки перед тим, як додаток зможе видалити фотографії, буде показано екран дозволу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只有在应用内手动启动照片备份时才会删除照片，因为在应用能够删除照片之前会显示一个权限屏幕。"
           }
         }
       }
@@ -15315,6 +17961,12 @@
             "state" : "translated",
             "value" : "Порт"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "端口"
+          }
         }
       }
     },
@@ -15348,6 +18000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Працює на базі Syncthing"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由 Syncthing 提供支持"
           }
         }
       }
@@ -15383,6 +18041,12 @@
             "state" : "translated",
             "value" : "Підготовка до збереження фото та відео"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "准备保存照片和视频"
+          }
         }
       }
     },
@@ -15416,6 +18080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Підготовка до синхронізації..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "准备同步..."
           }
         }
       }
@@ -15451,6 +18121,12 @@
             "state" : "translated",
             "value" : "Перегляд файлів при натисканні"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击预览文件"
+          }
         }
       }
     },
@@ -15484,6 +18160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Попередні перегляди"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预览"
           }
         }
       }
@@ -15519,6 +18201,12 @@
             "state" : "translated",
             "value" : "Попередній"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一个"
+          }
         }
       }
     },
@@ -15552,6 +18240,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Публічний URL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公共 URL"
           }
         }
       }
@@ -15587,6 +18281,12 @@
             "state" : "translated",
             "value" : "швидко"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quic"
+          }
         }
       }
     },
@@ -15617,6 +18317,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "QUIC"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "QUIC"
@@ -15655,6 +18361,12 @@
             "state" : "translated",
             "value" : "Вийти з Synctrain"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Synctrain"
+          }
         }
       }
     },
@@ -15688,6 +18400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кворум"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "法定人数"
           }
         }
       }
@@ -15723,6 +18441,12 @@
             "state" : "translated",
             "value" : "Повторно скопіювати всі фотографії"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新复制所有照片"
+          }
         }
       }
     },
@@ -15756,6 +18480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Знову зв'язати папку..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新链接文件夹..."
           }
         }
       }
@@ -15791,6 +18521,12 @@
             "state" : "translated",
             "value" : "Пересканувати папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描文件夹"
+          }
         }
       }
     },
@@ -15824,6 +18560,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Детальніше на syncthing.net"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 syncthing.net 阅读更多"
           }
         }
       }
@@ -15859,6 +18601,12 @@
             "state" : "translated",
             "value" : "Лише отримання"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅接收"
+          }
         }
       }
     },
@@ -15892,6 +18640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отримання %lld файлів..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接收 %lld 个文件..."
           }
         }
       }
@@ -15927,6 +18681,12 @@
             "state" : "translated",
             "value" : "Отримання файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接收文件"
+          }
         }
       }
     },
@@ -15960,6 +18720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отримання файлів..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接收文件中..."
           }
         }
       }
@@ -15995,6 +18761,12 @@
             "state" : "translated",
             "value" : "Останні зміни"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近更改"
+          }
         }
       }
     },
@@ -16028,6 +18800,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Створити структуру папок заново"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重建文件夹结构"
           }
         }
       }
@@ -16063,6 +18841,12 @@
             "state" : "translated",
             "value" : "Оновити"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新"
+          }
         }
       }
     },
@@ -16096,6 +18880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Звичайна папка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常规文件夹"
           }
         }
       }
@@ -16131,6 +18921,12 @@
             "state" : "translated",
             "value" : "Передача"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中继"
+          }
         }
       }
     },
@@ -16164,6 +18960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ідентифікатор реле"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继电器 ID"
           }
         }
       }
@@ -16199,6 +19001,12 @@
             "state" : "translated",
             "value" : "Реле-пул"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中继池"
+          }
         }
       }
     },
@@ -16232,6 +19040,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Залишилося"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩余"
           }
         }
       }
@@ -16267,6 +19081,12 @@
             "state" : "translated",
             "value" : "Видалити всі шаблони"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所有模式"
+          }
         }
       }
     },
@@ -16300,6 +19120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити файл з усіх пристроїв"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从所有设备中删除文件"
           }
         }
       }
@@ -16335,6 +19161,12 @@
             "state" : "translated",
             "value" : "Видалити файли"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除文件"
+          }
         }
       }
     },
@@ -16368,6 +19200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити файли з цього пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从此设备中删除文件"
           }
         }
       }
@@ -16403,6 +19241,12 @@
             "state" : "translated",
             "value" : "Видалити папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除文件夹"
+          }
         }
       }
     },
@@ -16436,6 +19280,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити з цього пристрою, зберегти на %lld інших"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从此设备移除，保留在其他%lld个设备上"
           }
         }
       }
@@ -16471,6 +19321,12 @@
             "state" : "translated",
             "value" : "Видалити збережені фото з джерела"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从源中删除已保存的照片"
+          }
         }
       }
     },
@@ -16504,6 +19360,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити вибрані файли з цього пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从此设备中删除所选文件"
           }
         }
       }
@@ -16539,6 +19401,12 @@
             "state" : "translated",
             "value" : "Видалити файл з усіх пристроїв"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从所有设备中删除该文件"
+          }
         }
       }
     },
@@ -16572,6 +19440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити файли, що показані у списку, з цього пристрою, але не видаляти їх з інших пристроїв. Якщо файл недоступний на принаймні одному іншому пристрої, він не буде видалений."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将列表中显示的文件从此设备中移除，但不要从其他设备中移除。如果某个文件在至少一个其他设备上不可用，则不会被移除。"
           }
         }
       }
@@ -16607,6 +19481,12 @@
             "state" : "translated",
             "value" : "Видаліть файли, показані в списку, з цього пристрою, але не видаляйте їх з інших пристроїв."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从此设备中移除列表中显示的文件，请勿从其他设备中移除。如果文件在其他设备上不可用，将被永久删除。"
+          }
         }
       }
     },
@@ -16640,6 +19520,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити папку та всі файли"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除文件夹及所有文件"
           }
         }
       }
@@ -16675,6 +19561,12 @@
             "state" : "translated",
             "value" : "Видалити ескізи з кешу програми"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从应用程序全局缓存中删除缩略图"
+          }
         }
       }
     },
@@ -16708,6 +19600,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити ескізи, згенеровані для файлів у цій папці, з кешу ескізів програми."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从应用程序的缩略图缓存中删除为此文件夹中的文件生成的缩略图。"
           }
         }
       }
@@ -16743,6 +19641,12 @@
             "state" : "translated",
             "value" : "Видалити не синхронізовані порожні підкаталоги"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除未同步的空子目录"
+          }
         }
       }
     },
@@ -16776,6 +19680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалити резервну копію бази даних v1"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除 v1 数据库备份"
           }
         }
       }
@@ -16811,6 +19721,12 @@
             "state" : "translated",
             "value" : "Видалення оригіналів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除原件"
+          }
         }
       }
     },
@@ -16844,6 +19760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Замінити наявний файл"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "替换现有文件"
           }
         }
       }
@@ -16879,6 +19801,12 @@
             "state" : "translated",
             "value" : "Повторне сканування"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描"
+          }
         }
       }
     },
@@ -16912,6 +19840,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пересканувати папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描文件夹"
           }
         }
       }
@@ -16947,6 +19881,12 @@
             "state" : "translated",
             "value" : "Інтервал повторного сканування (хвилини)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描间隔（分钟）"
+          }
         }
       }
     },
@@ -16980,6 +19920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пересканувати підкаталог"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描子目录"
           }
         }
       }
@@ -17015,6 +19961,12 @@
             "state" : "translated",
             "value" : "Перезапустіть додаток, щоб видалити базу даних v1"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新启动应用以移除 v1 数据库"
+          }
         }
       }
     },
@@ -17048,6 +20000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перезапустіть застосунок, щоб зупинити ведення журналу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新启动应用以停止日志记录。"
           }
         }
       }
@@ -17083,6 +20041,12 @@
             "state" : "translated",
             "value" : "Перевірте дозволи в додатку Налаштування"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在“设置”应用中查看权限"
+          }
         }
       }
     },
@@ -17116,6 +20080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Перевірка..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "审查..."
           }
         }
       }
@@ -17151,6 +20121,12 @@
             "state" : "translated",
             "value" : "Зберегти"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
         }
       }
     },
@@ -17184,6 +20160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зберегти наступні типи медіафайлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存以下媒体类型"
           }
         }
       }
@@ -17231,6 +20213,12 @@
             "state" : "translated",
             "value" : "Збережено %lld нових елементів."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存%lld个新项目。"
+          }
         }
       }
     },
@@ -17270,6 +20258,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Збережено %lld, очищено %lld елементів."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存 %lld，已清除 %lld 项。"
           }
         }
       }
@@ -17317,6 +20311,12 @@
             "state" : "translated",
             "value" : "Нові елементи не збережено, видалено %lld елементів."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未保存新项目，已清除 %lld 个项目。"
+          }
         }
       }
     },
@@ -17350,6 +20350,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зберігає всі фотографії з альбому в папку, навіть якщо фотографія вже була збережена в папці раніше. Це перезапише будь-які зміни, внесені у файл фотографії у папці."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将相册中的所有照片保存到文件夹，即使照片之前已保存到文件夹。此操作将覆盖已对文件夹中照片文件所做的任何修改。"
           }
         }
       }
@@ -17385,6 +20391,12 @@
             "state" : "translated",
             "value" : "Зберігає фото в альбомі, які раніше не були скопійовані у папку."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将相册中未曾复制到文件夹的照片保存下来。"
+          }
         }
       }
     },
@@ -17418,6 +20430,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Збереження live-фото"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存实况照片"
           }
         }
       }
@@ -17453,6 +20471,12 @@
             "state" : "translated",
             "value" : "Збереження фотографій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存照片"
+          }
         }
       }
     },
@@ -17486,6 +20510,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Збереження відео"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存视频"
           }
         }
       }
@@ -17521,6 +20551,12 @@
             "state" : "translated",
             "value" : "Сканувати QR-код пристрою"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扫描设备二维码"
+          }
         }
       }
     },
@@ -17554,6 +20590,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сканувати за допомогою камери..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用相机扫描..."
           }
         }
       }
@@ -17589,6 +20631,12 @@
             "state" : "translated",
             "value" : "Сканування..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在扫描..."
+          }
         }
       }
     },
@@ -17622,6 +20670,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пошук"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索"
           }
         }
       }
@@ -17657,6 +20711,12 @@
             "state" : "translated",
             "value" : "Шукати у всіх файлах та папках..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索所有文件和文件夹..."
+          }
         }
       }
     },
@@ -17690,6 +20750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пошук файлів за назвою..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按名称搜索文件..."
           }
         }
       }
@@ -17725,6 +20791,12 @@
             "state" : "translated",
             "value" : "Шукати файли у всіх папках..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在所有文件夹中搜索文件..."
+          }
         }
       }
     },
@@ -17758,6 +20830,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Шукати файли в додатку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在应用中搜索文件"
           }
         }
       }
@@ -17793,6 +20871,12 @@
             "state" : "translated",
             "value" : "Шукати файли в цій папці..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此文件夹中搜索文件..."
+          }
         }
       }
     },
@@ -17826,6 +20910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пошук"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索"
           }
         }
       }
@@ -17861,6 +20951,12 @@
             "state" : "translated",
             "value" : "Пошук файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索文件"
+          }
         }
       }
     },
@@ -17894,6 +20990,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Шукати тут..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此搜索..."
           }
         }
       }
@@ -17929,6 +21031,12 @@
             "state" : "translated",
             "value" : "Шукати в цій папці"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此文件夹中搜索"
+          }
         }
       }
     },
@@ -17962,6 +21070,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Шукати в цій папці..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此文件夹中搜索..."
           }
         }
       }
@@ -17997,6 +21111,12 @@
             "state" : "translated",
             "value" : "Шукати в цій підкаталозі..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在此子目录中搜索..."
+          }
         }
       }
     },
@@ -18030,6 +21150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Результати пошуку (%lld)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索结果 (%lld)"
           }
         }
       }
@@ -18065,6 +21191,12 @@
             "state" : "translated",
             "value" : "Результати пошуку (%lld+)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索结果 (%lld+)"
+          }
         }
       }
     },
@@ -18098,6 +21230,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пошуковий термін"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索词"
           }
         }
       }
@@ -18133,6 +21271,12 @@
             "state" : "translated",
             "value" : "Пошук за декількома критеріями для тієї ж властивості файлу наразі не підтримується."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前不支持对文件的同一属性使用多个标准进行搜索。"
+          }
         }
       }
     },
@@ -18166,6 +21310,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Виберіть папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择一个文件夹"
           }
         }
       }
@@ -18201,6 +21351,12 @@
             "state" : "translated",
             "value" : "Виберіть усі пристрої, що пропонують цю папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择提供此文件夹的所有设备"
+          }
         }
       }
     },
@@ -18234,6 +21390,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Виберіть папку конфігурації..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择配置文件夹..."
           }
         }
       }
@@ -18269,6 +21431,12 @@
             "state" : "translated",
             "value" : "Виберіть..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择..."
+          }
         }
       }
     },
@@ -18302,6 +21470,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вибрані файли"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择的文件"
           }
         }
       }
@@ -18337,6 +21511,12 @@
             "state" : "translated",
             "value" : "Вибрана папка не існує"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择的文件夹不存在"
+          }
         }
       }
     },
@@ -18370,6 +21550,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вибір файлів для синхронізації"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要同步的文件"
           }
         }
       }
@@ -18405,6 +21591,12 @@
             "state" : "translated",
             "value" : "Вибір"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择"
+          }
         }
       }
     },
@@ -18439,6 +21631,12 @@
             "state" : "translated",
             "value" : "Відправити та отримати"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发送和接收"
+          }
         }
       }
     },
@@ -18472,6 +21670,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тільки надіслати"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅发送"
           }
         }
       }
@@ -18519,6 +21723,12 @@
             "state" : "translated",
             "value" : "Відправка %lld файлів..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在发送 %lld 个文件..."
+          }
         }
       }
     },
@@ -18552,6 +21762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Надсилання файлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在发送文件"
           }
         }
       }
@@ -18587,6 +21803,12 @@
             "state" : "translated",
             "value" : "Відправлення файлів..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在发送文件..."
+          }
         }
       }
     },
@@ -18620,6 +21842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Встановити стандартні шаблони"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置默认模式"
           }
         }
       }
@@ -18655,6 +21883,12 @@
             "state" : "translated",
             "value" : "Налаштування"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置"
+          }
         }
       }
     },
@@ -18688,6 +21922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування для '%@'"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@”的设置"
           }
         }
       }
@@ -18723,6 +21963,12 @@
             "state" : "translated",
             "value" : "Налаштування..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置..."
+          }
         }
       }
     },
@@ -18756,6 +22002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділитися зовнішнім посиланням"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享外部链接"
           }
         }
       }
@@ -18791,6 +22043,12 @@
             "state" : "translated",
             "value" : "Поділитися файлом"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共享文件"
+          }
         }
       }
     },
@@ -18824,6 +22082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділитися папкою \"%@\""
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共享文件夹“%@”"
           }
         }
       }
@@ -18859,6 +22123,12 @@
             "state" : "translated",
             "value" : "Поділіться цією текою з іншими пристроями, щоб розпочати синхронізацію файлів."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将此文件夹与其他设备共享以开始同步文件。"
+          }
         }
       }
     },
@@ -18892,6 +22162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Поділитися з усіма пристроями, які пропонують цю папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共享给"
           }
         }
       }
@@ -18927,6 +22203,12 @@
             "state" : "translated",
             "value" : "Поділитися з пристроєм"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与设备共享"
+          }
         }
       }
     },
@@ -18960,6 +22242,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Спільні папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共享文件夹"
           }
         }
       }
@@ -18995,6 +22283,12 @@
             "state" : "translated",
             "value" : "Спільно з"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共享给"
+          }
         }
       }
     },
@@ -19028,6 +22322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Короткий ідентифікатор пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短设备ID"
           }
         }
       }
@@ -19063,6 +22363,12 @@
             "state" : "translated",
             "value" : "Показати"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示"
+          }
         }
       }
     },
@@ -19096,6 +22402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показати адреси"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示地址"
           }
         }
       }
@@ -19131,6 +22443,12 @@
             "state" : "translated",
             "value" : "Показати деталі"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示详情"
+          }
         }
       }
     },
@@ -19164,6 +22482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показати попередній перегляд зображень"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示图片预览"
           }
         }
       }
@@ -19199,6 +22523,12 @@
             "state" : "translated",
             "value" : "Показати у Finder"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Finder 中显示"
+          }
         }
       }
     },
@@ -19232,6 +22562,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показати інформацію"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示信息"
           }
         }
       }
@@ -19267,6 +22603,12 @@
             "state" : "translated",
             "value" : "Показати інформацію..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示信息..."
+          }
         }
       }
     },
@@ -19300,6 +22642,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показати екран введення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示介绍屏幕"
           }
         }
       }
@@ -19335,6 +22683,12 @@
             "state" : "translated",
             "value" : "Показати метрику"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示指标"
+          }
         }
       }
     },
@@ -19368,6 +22722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показати попередній перегляд"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示预览"
           }
         }
       }
@@ -19403,6 +22763,12 @@
             "state" : "translated",
             "value" : "Показати попередній перегляд для великих файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示大文件预览"
+          }
         }
       }
     },
@@ -19436,6 +22802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показати QR-код"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示二维码"
           }
         }
       }
@@ -19471,6 +22843,12 @@
             "state" : "translated",
             "value" : "Показати результати з прихованих папок"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示隐藏文件夹中的结果"
+          }
         }
       }
     },
@@ -19504,6 +22882,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показати ескізи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示缩略图"
           }
         }
       }
@@ -19539,6 +22923,12 @@
             "state" : "translated",
             "value" : "Показувати попередній перегляд відео"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示视频预览"
+          }
         }
       }
     },
@@ -19572,6 +22962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Одна папка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单个文件夹"
           }
         }
       }
@@ -19607,6 +23003,12 @@
             "state" : "translated",
             "value" : "Одна папка (дата в імені файлу)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单个文件夹（文件名中的日期）"
+          }
         }
       }
     },
@@ -19640,6 +23042,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Розмір"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小"
           }
         }
       }
@@ -19675,6 +23083,12 @@
             "state" : "translated",
             "value" : "Розмір на цьому пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上的大小"
+          }
         }
       }
     },
@@ -19708,6 +23122,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Почати"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始"
           }
         }
       }
@@ -19743,6 +23163,12 @@
             "state" : "translated",
             "value" : "Запущено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已开始"
+          }
         }
       }
     },
@@ -19776,6 +23202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Статистика"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "统计"
           }
         }
       }
@@ -19811,6 +23243,12 @@
             "state" : "translated",
             "value" : "Статистика..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "统计..."
+          }
         }
       }
     },
@@ -19844,6 +23282,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Статус"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "状态"
           }
         }
       }
@@ -19879,6 +23323,12 @@
             "state" : "translated",
             "value" : "Потік"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流"
+          }
         }
       }
     },
@@ -19909,6 +23359,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "STUN"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "STUN"
@@ -19947,6 +23403,12 @@
             "state" : "translated",
             "value" : "STUN-сервери"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "STUN服务器"
+          }
         }
       }
     },
@@ -19980,6 +23442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "STUN-сервери..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "STUN 服务器..."
           }
         }
       }
@@ -20015,6 +23483,12 @@
             "state" : "translated",
             "value" : "Порожні підкаталоги без файлів були видалені з цього пристрою."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从此设备中删除了空的且没有文件的子目录。"
+          }
         }
       }
     },
@@ -20048,6 +23522,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Підкаталог"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子目录"
           }
         }
       }
@@ -20083,6 +23563,12 @@
             "state" : "translated",
             "value" : "Властивості підкаталогу"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子目录属性"
+          }
         }
       }
     },
@@ -20116,6 +23602,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Властивості підкаталогу..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子目录属性..."
           }
         }
       }
@@ -20151,6 +23643,12 @@
             "state" : "translated",
             "value" : "Підшлях"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子路径"
+          }
         }
       }
     },
@@ -20184,6 +23682,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Проводьте пальцем між файлами під час перегляду"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看时在文件之间滑动"
           }
         }
       }
@@ -20219,6 +23723,12 @@
             "state" : "translated",
             "value" : "Перемикання рядків/стовпців"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换行/列"
+          }
         }
       }
     },
@@ -20252,6 +23762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Синхронізація не виконана"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步未运行"
           }
         }
       }
@@ -20287,6 +23803,12 @@
             "state" : "translated",
             "value" : "Синхронізацію вимкнено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步已禁用"
+          }
         }
       }
     },
@@ -20320,6 +23842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Синхронізацію для цієї папки вимкнено. Увімкніть її в налаштуваннях папки, щоб отримати доступ до файлів."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件夹的同步已被禁用。请在文件夹设置中启用以访问文件。"
           }
         }
       }
@@ -20355,6 +23883,12 @@
             "state" : "translated",
             "value" : "Синхронізацію вимкнено для всіх пов'язаних пристроїв. Це може статися після оновлення або перезапуску додатка. Щоб відновити синхронізацію, увімкніть її знову на сторінці 'пристрої', або натисніть тут, щоб увімкнути всі пристрої."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有关联设备的同步已禁用。这可能会在更新或重新启动应用后发生。要重新启动同步，请在“设备”页面重新启用同步，或点击这里启用所有设备。"
+          }
         }
       }
     },
@@ -20388,6 +23922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Синхронізація - це не резервне копіювання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步不是备份"
           }
         }
       }
@@ -20423,6 +23963,12 @@
             "state" : "translated",
             "value" : "Синхронізація призупинена"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步已暂停"
+          }
         }
       }
     },
@@ -20456,6 +24002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Синхронізувати"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步"
           }
         }
       }
@@ -20491,6 +24043,12 @@
             "state" : "translated",
             "value" : "Синхронізувати на деякий час"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步一会儿"
+          }
         }
       }
     },
@@ -20524,6 +24082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Синхронізувати з цим пристроєм"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与此设备同步"
           }
         }
       }
@@ -20559,6 +24123,12 @@
             "state" : "translated",
             "value" : "Синхронізуйте ваші файли безпечно з іншими вашими пристроями."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全地与您的其他设备同步文件。"
+          }
         }
       }
     },
@@ -20592,6 +24162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Синхронізовано"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已同步"
           }
         }
       }
@@ -20627,6 +24203,12 @@
             "state" : "translated",
             "value" : "Синхронізується..."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在同步..."
+          }
         }
       }
     },
@@ -20657,6 +24239,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncthing"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Syncthing"
@@ -20695,6 +24283,12 @@
             "state" : "translated",
             "value" : "Synctrain"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步"
+          }
         }
       }
     },
@@ -20728,6 +24322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Synctrain більше не може отримати доступ до цієї папки. Натисніть кнопку нижче, щоб заново вибрати папку на вашій системі. Це має знову надати Synctrain доступ до папки."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synctrain 无法再访问此文件夹。请点击下面的按钮以在您的系统中重新选择该文件夹。这应该会重新授予 Synctrain 对该文件夹的访问权限。"
           }
         }
       }
@@ -20763,6 +24363,12 @@
             "state" : "translated",
             "value" : "Synctrain наразі не може отримати доступ до вашої фототеки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synctrain 目前无法访问您的照片库"
+          }
         }
       }
     },
@@ -20796,6 +24402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Synctrain є © 2024-2025, Tommy van der Vorst"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synctrain 是 © 2024-2025，Tommy van der Vorst"
           }
         }
       }
@@ -20831,6 +24443,12 @@
             "state" : "translated",
             "value" : "Системні файли"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统文件"
+          }
         }
       }
     },
@@ -20864,6 +24482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування системи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统设置"
           }
         }
       }
@@ -20899,6 +24523,12 @@
             "state" : "translated",
             "value" : "Торкніться тут, щоб переглянути завантажений файл"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点这里查看已下载的文件"
+          }
         }
       }
     },
@@ -20933,6 +24563,12 @@
             "state" : "translated",
             "value" : "Натисніть, щоб закрити"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轻触以关闭"
+          }
         }
       }
     },
@@ -20963,6 +24599,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tcp"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "tcp"
@@ -21001,6 +24643,12 @@
             "state" : "translated",
             "value" : "TCP"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TCP"
+          }
         }
       }
     },
@@ -21034,6 +24682,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "3D модель для логотипу була розроблена [Kai Werder](https://werder.fyi) у 2025 році за допомогою Blender 4.5.1 LTS і поширюється згідно з Mozilla Public License 2.0."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "徽标的3D模型由[Kai Werder](https://werder.fyi)于2025年使用Blender 4.5.1 LTS设计，按照Mozilla公共许可证2.0进行分发。"
           }
         }
       }
@@ -21069,6 +24723,12 @@
             "state" : "translated",
             "value" : "Додаток в даний час використовує налаштування з файлу config.xml у директорії програми. Видаліть його та перезавантажте додаток, щоб повернутися до стандартних налаштувань."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该应用当前正在使用应用目录中的 config.xml 自定义配置。移除并重启应用以恢复默认配置。"
+          }
         }
       }
     },
@@ -21102,6 +24762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Додаток веде журнал у файл в папці програми, який ви можете поділитися з розробниками."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该应用程序正在记录到应用程序文件夹中的一个文件，您可以与开发人员共享。"
           }
         }
       }
@@ -21137,6 +24803,12 @@
             "state" : "translated",
             "value" : "Додаток потрібно відкрити в активному режимі хоча б один раз, щоб оновити базу даних."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用需要至少在前台打开一次以升级数据库。"
+          }
         }
       }
     },
@@ -21170,6 +24842,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файл конфігурації було збережено у папці застосунку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置文件已保存在应用程序文件夹中。"
           }
         }
       }
@@ -21205,6 +24883,12 @@
             "state" : "translated",
             "value" : "Папка конфігурації містить налаштування для додатка, а також ключі для зв'язку з іншими пристроями та облік синхронізованих папок. За замовчуванням, папка конфігурації управляється додатком."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置文件夹包含应用程序的设置，以及与其他设备通信的密钥和同步文件夹的记录。默认情况下，配置文件夹由应用程序管理。"
+          }
         }
       }
     },
@@ -21238,6 +24922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Дати в назвах/шляхах файлів завжди будуть у часовій зоні '%@'. Якщо фотографія була зроблена в іншій часовій зоні та близько опівночі, день може відрізнятися. Зміна цього налаштування може призвести до повторного збереження фотографій."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件名/路径中的日期将始终位于“%@”时区。如果照片是在不同的时区拍摄且接近午夜，日期可能会有所不同。更改此设置可能导致照片再次保存。"
           }
         }
       }
@@ -21273,6 +24963,12 @@
             "state" : "translated",
             "value" : "Дати у назвах/шляхах файлів будуть у налаштованому часовому поясі вашого пристрою на момент виконання резервного копіювання. Це може спричинити експорт елементів більше ніж один раз при переміщенні між часовими поясами. Зміна цього налаштування може призвести до того, що фото буде збережено знову."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件名/路径中的日期将在备份时处于设备配置的时区。这可能导致在不同时区之间移动时重复导出项目。更改此设置可能会导致照片再次保存。"
+          }
         }
       }
     },
@@ -21306,6 +25002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пристрій було додано"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备已添加"
           }
         }
       }
@@ -21341,6 +25043,12 @@
             "state" : "translated",
             "value" : "Пристрій додано. Щоб забезпечити з'єднання, переконайтеся, що інший пристрій приймає цей пристрій, або додайте цей пристрій туди також."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备已添加。为了确保连接，请确保其他设备接受该设备，或者也将该设备添加到那里。"
+          }
         }
       }
     },
@@ -21374,6 +25082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пристрій для відображення файлів для"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用于列出文件的设备"
           }
         }
       }
@@ -21409,6 +25123,12 @@
             "state" : "translated",
             "value" : "Пристрій для переналаштування"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要重新配置的设备"
+          }
         }
       }
     },
@@ -21442,6 +25162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Файл наразі недоступний для перегляду."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件当前无法预览。"
           }
         }
       }
@@ -21477,6 +25203,12 @@
             "state" : "translated",
             "value" : "Файли для завантаження"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要下载的文件"
+          }
         }
       }
     },
@@ -21510,6 +25242,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папку неможливо відкрити"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法访问文件夹"
           }
         }
       }
@@ -21545,6 +25283,12 @@
             "state" : "translated",
             "value" : "Папка, для якої потрібно отримати каталог"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要检索目录的文件夹"
+          }
         }
       }
     },
@@ -21578,6 +25322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "папка не має локального шляху"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹没有本地路径"
           }
         }
       }
@@ -21613,6 +25363,12 @@
             "state" : "translated",
             "value" : "Папка доступна."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹是可访问的。"
+          }
         }
       }
     },
@@ -21646,6 +25402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка не налаштована для вибіркової синхронізації."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹未配置为选择性同步。"
           }
         }
       }
@@ -21681,6 +25443,12 @@
             "state" : "translated",
             "value" : "Папка для перелічення файлів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要列出文件的文件夹"
+          }
         }
       }
     },
@@ -21714,6 +25482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тека для повторної конфігурації"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要重新配置的文件夹"
           }
         }
       }
@@ -21749,6 +25523,12 @@
             "state" : "translated",
             "value" : "Файл наразі недоступний для попереднього перегляду."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要重新扫描的文件夹"
+          }
         }
       }
     },
@@ -21782,6 +25562,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Папка, яку ви обрали, знаходиться всередині папки програми. Можна вибрати лише папки поза папкою програми."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您选择的文件夹位于应用文件夹内。只能选择应用文件夹外的文件夹。"
           }
         }
       }
@@ -21817,6 +25603,12 @@
             "state" : "translated",
             "value" : "Операційна система періодично надаватиме додатку кілька хвилин у фоновому режимі, залежно від доступності мережі та стану батареї."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作系统将根据网络连接和电池状态，定期给予应用程序几分钟的后台运行时间。"
+          }
         }
       }
     },
@@ -21850,6 +25642,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Шлях до папки з налаштуваннями було змінено і він буде використаний при перезапуску додатка. Додаток зараз закриється."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置文件夹的路径已更改，将在应用重新启动时使用。应用将立即关闭。"
           }
         }
       }
@@ -21885,6 +25683,12 @@
             "state" : "translated",
             "value" : "Відсоток файлів, які пристрій синхронізував, відносно частини папки, яку він хоче синхронізувати. Оскільки пристрої можуть ігнорувати певні файли або взагалі не синхронізувати жодних файлів, відсоток не вказує на відсоток повної папки, фактично присутньої на пристрої."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备已同步的文件百分比，相对于它想要同步的文件夹部分。由于设备可能会忽略某些文件或完全不同步任何文件，因此这个百分比并不表示设备上实际存在的完整文件夹的百分比。"
+          }
         }
       }
     },
@@ -21918,6 +25722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Кворум має бути позитивним числом."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "法定人数必须是一个正数。"
           }
         }
       }
@@ -21953,6 +25763,12 @@
             "state" : "translated",
             "value" : "Запитувана дія не підтримується: %@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不支持请求的操作：%@"
+          }
         }
       }
     },
@@ -21986,6 +25802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Екран залишатиметься увімкненим, поки не завершиться"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屏幕将保持开启直至完成"
           }
         }
       }
@@ -22021,6 +25843,12 @@
             "state" : "translated",
             "value" : "Вибрану папку не можна використовувати для збереження фото"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法将照片保存到选定的文件夹"
+          }
         }
       }
     },
@@ -22054,6 +25882,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вихідний код цього додатка доступний за ліцензією Mozilla Public License 2.0."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此应用程序的源代码可在 Mozilla 公共许可证 2.0 下提供。"
           }
         }
       }
@@ -22089,6 +25923,12 @@
             "state" : "translated",
             "value" : "Підкаталог для повторного сканування (залиште порожнім, щоб повторно сканувати всю папку)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要重新扫描的子目录（留空以重新扫描整个文件夹）"
+          }
         }
       }
     },
@@ -22122,6 +25962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування синхронізації для символічних посилань неможливо змінити."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法更改符号链接的同步设置。"
           }
         }
       }
@@ -22157,6 +26003,12 @@
             "state" : "translated",
             "value" : "Налаштування синхронізації для цього елемента не можна змінити, оскільки локальна копія є єдиною доступною копією."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法更改此项目的同步设置，因为本地副本是目前唯一可用的副本。"
+          }
         }
       }
     },
@@ -22190,6 +26042,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Налаштування синхронізації для цього елемента не можна змінити, оскільки він знаходиться в підкаталозі, який налаштований на збереження на цьому пристрої."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法更改此项目的同步设置，因为它位于配置为保留在此设备上的子目录中。"
           }
         }
       }
@@ -22225,6 +26083,12 @@
             "state" : "translated",
             "value" : "Налаштування синхронізації для цього елемента не вдалося змінити: %@."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此项目的同步设置无法更改：%@。"
+          }
         }
       }
     },
@@ -22258,6 +26122,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Зараз у цій папці немає файлів."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前文件夹中没有文件。"
           }
         }
       }
@@ -22293,6 +26163,12 @@
             "state" : "translated",
             "value" : "Наразі немає інших пристроїв, підключених із повною копією цього файлу."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前没有其他设备连接，拥有此文件的完整副本。"
+          }
         }
       }
     },
@@ -22326,6 +26202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "На даний момент немає інших підключених пристроїв, тому не може бути встановлено, що цей файл повністю доступний на принаймні одному іншому пристрої."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前没有其他设备连接，因此无法确定此文件在至少一个其他设备上完全可用。"
           }
         }
       }
@@ -22361,6 +26243,12 @@
             "state" : "translated",
             "value" : "На цьому пристрої майже не залишилося вільного місця для зберігання."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备几乎没有剩余的存储空间。"
+          }
         }
       }
     },
@@ -22394,6 +26282,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "На цьому пристрої залишилося лише %@ вільного місця."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备上只剩下 %@ 的可用存储空间。"
           }
         }
       }
@@ -22429,6 +26323,12 @@
             "state" : "translated",
             "value" : "Доступно дуже мало місця на диску. Звільніть трохи місця та спробуйте знову."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁盘可用空间很少。请释放一些空间然后重试。"
+          }
         }
       }
     },
@@ -22462,6 +26362,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не було нових елементів для збереження."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有新的项目需要保存。"
           }
         }
       }
@@ -22497,6 +26403,12 @@
             "state" : "translated",
             "value" : "Цей додаток працює завдяки Syncthing. Проте, цей додаток не є пов’язаним або підтримуваним Syncthing чи його розробниками. Будь ласка, не очікуйте підтримки від розробників Syncthing. Натомість звертайтесь до розробника цього додатку, якщо у вас є запитання."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此应用程序由 Syncthing 提供支持。然而，此应用程序与 Syncthing 或其开发人员没有关联，也未得到其认可。因此，请不要期望从 Syncthing 开发人员处获得支持。如有问题，请联系此应用的制作人。"
+          }
         }
       }
     },
@@ -22530,6 +26442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Цей додаток містить Syncthing, що є програмним забезпеченням з відкритим кодом під ліцензією Mozilla Public License 2.0. Syncthing є торговою маркою Syncthing Foundation. Цей додаток не пов'язаний і не схвалений Syncthing Foundation або учасниками проекту Syncthing."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此应用程序包含Syncthing，该软件是根据Mozilla公共许可证2.0的开源软件。Syncthing是Syncthing基金会的商标。本应用程序与Syncthing基金会或Syncthing贡献者无关，也未获其支持。"
           }
         }
       }
@@ -22565,6 +26483,12 @@
             "state" : "translated",
             "value" : "Цей пристрій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备"
+          }
         }
       }
     },
@@ -22599,6 +26523,12 @@
             "state" : "translated",
             "value" : "Цей пристрій має копію всіх елементів"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备拥有所有项目的副本"
+          }
         }
       }
     },
@@ -22632,6 +26562,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Цей пристрій має всі файли, які він хоче"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备已拥有其需要的所有文件"
           }
         }
       }
@@ -22673,6 +26609,12 @@
             "state" : "translated",
             "value" : "Цьому пристрою все ще потрібно %@ з %@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备仍需 %@/%@"
+          }
         }
       }
     },
@@ -22713,6 +26655,12 @@
             "state" : "translated",
             "value" : "Цьому пристрою ще потрібно %lld елементів із %lld"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备仍需 %lld 个项目，共 %lld 个"
+          }
         }
       }
     },
@@ -22746,6 +26694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Цей пристрій автоматично додасть усі пристрої, підключені до пристрою-інтроуктора."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该设备将自动添加引导设备连接的所有设备。"
           }
         }
       }
@@ -22781,6 +26735,12 @@
             "state" : "translated",
             "value" : "Ідентифікатор цього пристрою"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备的标识符"
+          }
         }
       }
     },
@@ -22814,6 +26774,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Цей файл повністю доступний на"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件已完整可用于"
           }
         }
       }
@@ -22849,6 +26815,12 @@
             "state" : "translated",
             "value" : "Цей файл не повністю доступний на жодному підключеному пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件在任何连接的设备上都不可完全用"
+          }
         }
       }
     },
@@ -22882,6 +26854,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Цей файл доступний лише на цьому пристрої."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件仅在此设备上可用。"
           }
         }
       }
@@ -22917,6 +26895,12 @@
             "state" : "translated",
             "value" : "Цей файл було видалено."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件已被删除。"
+          }
         }
       }
     },
@@ -22950,6 +26934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ця папка містить нові файли"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件夹有新文件"
           }
         }
       }
@@ -22985,6 +26975,12 @@
             "state" : "translated",
             "value" : "Ця папка є зовнішньою для цього застосунку і більше не може бути доступна. Щоб вирішити цю проблему, відключіть папку та додайте її знову."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件夹是此应用程序外部文件，无法再访问。要解决此问题，请取消链接此文件夹并重新添加。"
+          }
         }
       }
     },
@@ -23018,6 +27014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ця папка знаходиться не в стандартному місці і може належати до іншого додатка."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件夹不在默认位置，可能属于其他应用。"
           }
         }
       }
@@ -23053,6 +27055,12 @@
             "state" : "translated",
             "value" : "Цю папку було видалено."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件夹已被删除。"
+          }
         }
       }
     },
@@ -23086,6 +27094,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ця папка була видалена."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该文件夹已被移除。"
           }
         }
       }
@@ -23121,6 +27135,12 @@
             "state" : "translated",
             "value" : "Це розширена функція і її слід використовувати лише якщо ви знаєте, що робите."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这是一个高级功能，仅在您知道自己在做什么的情况下使用。"
+          }
         }
       }
     },
@@ -23154,6 +27174,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Цей елемент синхронізується з цим пристроєм, оскільки батьківська папка синхронізована з цим пристроєм."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此项目与此设备同步，因为父文件夹与此设备同步。"
           }
         }
       }
@@ -23189,6 +27215,12 @@
             "state" : "translated",
             "value" : "Цю сторінку не вдалося знайти"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到此页面"
+          }
         }
       }
     },
@@ -23222,6 +27254,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Цей підкаталог та весь його вміст повністю доступні на"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该子目录及其所有内容完全可用在"
           }
         }
       }
@@ -23257,6 +27295,12 @@
             "state" : "translated",
             "value" : "Це видалить всі файли з налаштованої підтеки. Ви впевнені, що хочете продовжити?"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这将删除配置子目录中的所有文件。您确定要继续吗？"
+          }
         }
       }
     },
@@ -23290,6 +27334,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Це видалить усі локально збережені копії файлів у цій папці. Будь-які файли, які не зберігаются на іншому пристрої, будуть безповоротно втрачені і не можуть бути відновлені. Ви впевнені, що хочете продовжити?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这将删除此文件夹中所有本地存储的文件副本。任何未在其他设备上存在的文件将永久丢失且无法恢复。您确定要继续吗？"
           }
         }
       }
@@ -23325,6 +27375,12 @@
             "state" : "translated",
             "value" : "Це видалить усі локально збережені копії файлів у цій теці. Файли, які не присутні на іншому пристрої, не будуть видалені. Ви впевнені, що хочете продовжити?"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这将删除此文件夹中所有本地存储的文件副本。任何在其他设备上不存在的文件都不会被删除。您确定要继续吗？"
+          }
         }
       }
     },
@@ -23358,6 +27414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Це видалить локальну копію вибраних файлів у цій папці. Файли, які не присутні на іншому пристрої, не будуть видалені. Ви впевнені, що хочете продовжити?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这将删除此文件夹中所选文件的本地副本。任何未在其他设备上存在的文件将不会被删除。您确定要继续吗？"
           }
         }
       }
@@ -23393,6 +27455,12 @@
             "state" : "translated",
             "value" : "Мініатюри"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缩略图"
+          }
         }
       }
     },
@@ -23426,6 +27494,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Час (секунди)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时间（秒）"
           }
         }
       }
@@ -23461,6 +27535,12 @@
             "state" : "translated",
             "value" : "Щоб отримати доступ до цієї сторінки, вам потрібно увійти в систему."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要访问此页面，您需要登录"
+          }
         }
       }
     },
@@ -23494,6 +27574,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "До папки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "至文件夹"
           }
         }
       }
@@ -23529,6 +27615,12 @@
             "state" : "translated",
             "value" : "Щоб зберегти файли на цьому пристрої, перейдіть до файлу та виберіть 'залишити на цьому пристрої'. Вибрані файли з'являться тут."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要在此设备上保留文件，请导航到文件并选择“保留在此设备上”。选中的文件将显示在此处。"
+          }
         }
       }
     },
@@ -23562,6 +27654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Щоб уникнути проблем, синхронізація тимчасово відключена. Щоб відновити синхронізацію, звільніть місце на пристрої, видаляючи файли, і/або зніміть вибір окремих файлів у вибірково синхронізованих папках. Якщо є доступне місце, очистіть кошик, перезапустіть додаток та пристрій."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为防止问题出现，已临时禁用同步。要恢复同步，请通过删除文件和/或取消选择在选择性同步文件夹中要同步的文件来释放设备上的空间。如果有可用空间，请清空垃圾桶，重新启动应用程序和设备。"
           }
         }
       }
@@ -23597,6 +27695,12 @@
             "state" : "translated",
             "value" : "У підкаталог"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到子目录"
+          }
         }
       }
     },
@@ -23630,6 +27734,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Щоб синхронізувати файли, додайте папку. Папки з однаковим ID папки на кількох пристроях будуть синхронізовані між собою."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要同步文件，请添加一个文件夹。在多个设备上具有相同文件夹ID的文件夹将彼此同步。"
           }
         }
       }
@@ -23665,6 +27775,12 @@
             "state" : "translated",
             "value" : "Щоб синхронізувати файли, спочатку додайте віддалений пристрій. Або виберіть пристрій зі списку нижче, або додайте вручну, використовуючи ідентифікатор пристрою."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要同步文件，首先添加一个远程设备。可以从下方列表中选择设备，或者使用设备ID手动添加。"
+          }
         }
       }
     },
@@ -23698,6 +27814,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Занадто багато файлів (%lld) для відображення."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件太多（%lld）无法显示。"
           }
         }
       }
@@ -23733,6 +27855,12 @@
             "state" : "translated",
             "value" : "Загальний розмір папки"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件夹总大小"
+          }
         }
       }
     },
@@ -23766,6 +27894,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Загальна кількість файлів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件总数"
           }
         }
       }
@@ -23801,6 +27935,12 @@
             "state" : "translated",
             "value" : "Довірений"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "信任的"
+          }
         }
       }
     },
@@ -23834,6 +27974,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Введіть"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入"
           }
         }
       }
@@ -23869,6 +28015,12 @@
             "state" : "translated",
             "value" : "Незашифрований"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未加密"
+          }
         }
       }
     },
@@ -23902,6 +28054,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Некодовані посилання для спільного доступу"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未加密的共享链接"
           }
         }
       }
@@ -23937,6 +28095,12 @@
             "state" : "translated",
             "value" : "Невідомий пристрій"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知设备"
+          }
         }
       }
     },
@@ -23970,6 +28134,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "невідома помилка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知错误"
           }
         }
       }
@@ -24005,6 +28175,12 @@
             "state" : "translated",
             "value" : "Невідомий стан"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知状态"
+          }
         }
       }
     },
@@ -24038,6 +28214,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Від'єднати пристрій"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解除设备链接"
           }
         }
       }
@@ -24073,6 +28255,12 @@
             "state" : "translated",
             "value" : "Від'єднати пристрої"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消设备链接"
+          }
         }
       }
     },
@@ -24106,6 +28294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відключити папку"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解除文件夹链接"
           }
         }
       }
@@ -24141,6 +28335,12 @@
             "state" : "translated",
             "value" : "Від'єднати папку"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消关联文件夹"
+          }
         }
       }
     },
@@ -24174,6 +28374,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Видалено несинхронізовані порожні підкаталоги"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已删除未同步的空子目录"
           }
         }
       }
@@ -24209,6 +28415,12 @@
             "state" : "translated",
             "value" : "Оновлено о"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "升级于"
+          }
         }
       }
     },
@@ -24242,6 +28454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Оновлення бази даних. Це може зайняти кілька хвилин, залежно від кількості ваших файлів. Будь ласка, не закривайте програму, доки оновлення не завершиться."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在升级数据库。根据您的文件数量，这可能需要几分钟时间。请不要在此期间关闭应用程序，直到完成为止。"
           }
         }
       }
@@ -24277,6 +28495,12 @@
             "state" : "translated",
             "value" : "Час роботи"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在线时间"
+          }
         }
       }
     },
@@ -24307,6 +28531,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL"
@@ -24345,6 +28575,12 @@
             "state" : "translated",
             "value" : "Використовуйте кеш програми"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用应用程序全局缓存"
+          }
         }
       }
     },
@@ -24378,6 +28614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Використовувати стандартні адреси"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用默认地址"
           }
         }
       }
@@ -24413,6 +28655,12 @@
             "state" : "translated",
             "value" : "Використовувати розташування конфігурації за замовчуванням"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用默认配置位置"
+          }
         }
       }
     },
@@ -24446,6 +28694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Використовувати пароль для пристрою"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用设备密码"
           }
         }
       }
@@ -24481,6 +28735,12 @@
             "state" : "translated",
             "value" : "Використовуйте часовий пояс"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用时区"
+          }
         }
       }
     },
@@ -24511,6 +28771,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v1"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "v1"
@@ -24549,6 +28815,12 @@
             "state" : "translated",
             "value" : "v2"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v2"
+          }
         }
       }
     },
@@ -24582,6 +28854,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Варіант"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "变体"
           }
         }
       }
@@ -24617,6 +28895,12 @@
             "state" : "translated",
             "value" : "Інформація про версію"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本信息"
+          }
         }
       }
     },
@@ -24650,6 +28934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Відео/IMG_2020.MOV"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频/IMG_2020.MOV"
           }
         }
       }
@@ -24685,6 +28975,12 @@
             "state" : "translated",
             "value" : "Відео"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频"
+          }
         }
       }
     },
@@ -24718,6 +29014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Переглянути як"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看为"
           }
         }
       }
@@ -24753,6 +29055,12 @@
             "state" : "translated",
             "value" : "Переглянути файл"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看文件"
+          }
         }
       }
     },
@@ -24786,6 +29094,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Переглянути налаштування"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看设置"
           }
         }
       }
@@ -24821,6 +29135,12 @@
             "state" : "translated",
             "value" : "Видимість"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可见性"
+          }
         }
       }
     },
@@ -24854,6 +29174,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очікування завершення"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待完成"
           }
         }
       }
@@ -24889,6 +29215,12 @@
             "state" : "translated",
             "value" : "Дочекайтеся, поки папка завершить синхронізацію, і спробуйте ще раз."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待文件夹同步完成后再试一次。"
+          }
         }
       }
     },
@@ -24922,6 +29254,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Очікування синхронізації..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待同步..."
           }
         }
       }
@@ -24957,6 +29295,12 @@
             "state" : "translated",
             "value" : "Слідкуйте за змінами"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "监视更改"
+          }
         }
       }
     },
@@ -24990,6 +29334,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Вебсторінка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网页"
           }
         }
       }
@@ -25025,6 +29375,12 @@
             "state" : "translated",
             "value" : "Ласкаво просимо до Synctrain!"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欢迎使用Synctrain！"
+          }
         }
       }
     },
@@ -25058,6 +29414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Що мені робити далі?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我现在该怎么办？"
           }
         }
       }
@@ -25093,6 +29455,12 @@
             "state" : "translated",
             "value" : "Коли папка містить файл з назвою 'index.html', він автоматично відобразиться як веб-сторінка."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当文件夹包含名为“index.html”的文件时，它将自动显示为网页。"
+          }
         }
       }
     },
@@ -25126,6 +29494,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли папка містить лише зображення, вона автоматично відображатиметься у вигляді сітки, а не списку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当文件夹仅包含图像时，它将自动以网格而非列表显示。"
           }
         }
       }
@@ -25161,6 +29535,12 @@
             "state" : "translated",
             "value" : "Коли фонову синхронізацію завершено"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "后台同步完成时"
+          }
         }
       }
     },
@@ -25194,6 +29574,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли дисковий простір обмежений, система може вирішити видалити деякі ескізи, щоб звільнити місце."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当硬盘空间不足时，系统可能会决定删除一些缩略图以释放空间。"
           }
         }
       }
@@ -25229,6 +29615,12 @@
             "state" : "translated",
             "value" : "Коли цей параметр ввімкнено, певні файли, створені системою (наприклад, .DS_Store), не будуть помічені як 'нові файли' у вибірково синхронізованих папках. Ці файли все одно будуть синхронізуватися в папках, що повністю синхронізуються, і коли вони створені іншими пристроями."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后，系统创建的某些文件（如.DS_Store）在选择性同步的文件夹中不会被识别为\"新文件\"。这些文件仍会在完全同步的文件夹中同步，也会在被其他设备创建时同步。"
+          }
         }
       }
     },
@@ -25262,6 +29654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли цей параметр увімкнено, файли і каталоги, ім'я яких починається з крапки, не відображатимуться під час перегляду папки. Ці файли і каталоги залишатимуться видимими в результатах пошуку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后，名称以点开头的文件和目录在浏览文件夹时将不会显示。这些文件和目录将在搜索结果中保持可见。"
           }
         }
       }
@@ -25297,6 +29695,12 @@
             "state" : "translated",
             "value" : "Коли увімкнено, додаток буде слухати на стандартних адресах і використовувати стандартний пул ретрансляторів."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后，应用程序将在默认地址上监听，并将使用默认中继池。"
+          }
         }
       }
     },
@@ -25330,6 +29734,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли ввімкнено, додаток автоматично знаходить адреси для цього пристрою за допомогою різних механізмів виявлення."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后，应用将使用各种发现机制自动查找此设备的地址。"
           }
         }
       }
@@ -25365,6 +29775,12 @@
             "state" : "translated",
             "value" : "Коли ввімкнено, додаток використовуватиме стандартну службу виявлення для оголошення про себе."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后，应用将使用默认的发现服务来宣布自己。"
+          }
         }
       }
     },
@@ -25398,6 +29814,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли ввімкнено, додаток буде використовувати стандартні STUN-сервери."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后，应用将使用默认的STUN服务器。"
           }
         }
       }
@@ -25433,6 +29855,12 @@
             "state" : "translated",
             "value" : "Коли остання синхронізація була давно."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次同步已经是很久以前的事了"
+          }
         }
       }
     },
@@ -25466,6 +29894,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли кеш увімкнено, ескізи завантажуються швидше і використовують менше даних при повторному перегляді."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用缓存后，缩略图加载速度更快，重复查看时使用更少的数据。"
           }
         }
       }
@@ -25501,6 +29935,12 @@
             "state" : "translated",
             "value" : "Коли структура папок змінюється, фотографії, які вже були збережені, будуть збережені знову в новому місці."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当文件夹结构更改时，已保存的照片将重新保存在新位置。"
+          }
         }
       }
     },
@@ -25534,6 +29974,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли ця настройка ввімкнена, додаток не намагатиметься підключитися до інших пристроїв після встановлення одного з'єднання."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用此设置后，应用将在建立一个连接后不会尝试连接更多设备。"
           }
         }
       }
@@ -25569,6 +30015,12 @@
             "state" : "translated",
             "value" : "Коли ви виберете цей файл, він не буде одразу доступний на цьому пристрої, оскільки жоден із підключених зараз пристроїв не має повної копії файлу, яку можна завантажити."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当您选择此文件时，它不会立即在此设备上可用，因为当前连接的设备中没有任何一台拥有可供下载的完整文件副本。"
+          }
         }
       }
     },
@@ -25602,6 +30054,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Коли ви вибираєте цей файл, він не стане відразу доступним на цьому пристрої, оскільки немає інших пристроїв, підключених для завантаження файлу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择此文件时，它不会立即在此设备上可用，因为没有其他设备连接来下载该文件。"
           }
         }
       }
@@ -25637,6 +30095,12 @@
             "state" : "translated",
             "value" : "Коли ви синхронізуєте файли, всі зміни, включаючи видалення файлів, також будуть відображені на інших ваших пристроях. Не використовуйте Synctrain для резервного копіювання і завжди зберігайте резервну копію своїх даних."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当您同步文件时，所有更改，包括删除文件，也会在您的其他设备上发生。不建议将Synctrain用于备份目的，请始终保留数据的备份。"
+          }
         }
       }
     },
@@ -25670,6 +30134,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Під час заряджання (довго)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "充电时（长时间）"
           }
         }
       }
@@ -25705,6 +30175,12 @@
             "state" : "translated",
             "value" : "На батареї (короткий)"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在电池供电时"
+          }
         }
       }
     },
@@ -25735,6 +30211,12 @@
           }
         },
         "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "XXXX-XXXX"
+          }
+        },
+        "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "XXXX-XXXX"
@@ -25773,6 +30255,12 @@
             "state" : "translated",
             "value" : "Рік"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年"
+          }
         }
       }
     },
@@ -25806,6 +30294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Рік-місяць"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年-月"
           }
         }
       }
@@ -25841,6 +30335,12 @@
             "state" : "translated",
             "value" : "Рік-місяць/Тип"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年-月/类型"
+          }
         }
       }
     },
@@ -25874,6 +30374,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Рік/Місяць"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年/月"
           }
         }
       }
@@ -25909,6 +30415,12 @@
             "state" : "translated",
             "value" : "Рік/Місяць/День"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年/月/日"
+          }
         }
       }
     },
@@ -25942,6 +30454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Рік/Місяць/День/Тип"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年/月/日/类型"
           }
         }
       }
@@ -25977,6 +30495,12 @@
             "state" : "translated",
             "value" : "Рік/Місяць/Тип"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年/月/类型"
+          }
         }
       }
     },
@@ -26010,6 +30534,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Рік/Тип"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年份/类型"
           }
         }
       }
@@ -26045,6 +30575,12 @@
             "state" : "translated",
             "value" : "Ви додаєте папку, якою може керувати інший додаток. Це може спричинити проблеми, наприклад, коли синхронізація змінює структуру файлів додатка в непідтримуваному форматі. Ви впевнені, що хочете продовжити?"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您正在添加一个可能由其他应用控制的文件夹。这可能会导致问题，例如当同步以不受支持的方式更改应用的文件结构时。您确定要继续吗？"
+          }
         }
       }
     },
@@ -26078,6 +30614,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ви використовуєте користувацьку конфігурацію. Це може використовуватись лише для тестування та на ваш власний ризик. Не всі параметри конфігурації можуть бути підтримані. Щоб вимкнути користувацьку конфігурацію, видаліть файли конфігурації з папки додатка і перезапустіть додаток. Розробники додатку не несуть відповідальності за можливу втрату даних!"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您正在使用自定义配置。这仅可用于测试，并需自行承担风险。并非所有配置选项都可能受支持。要禁用自定义配置，请从应用程序的文件夹中删除配置文件并重新启动应用程序。应用程序的开发者不对可能发生的数据丢失负责！"
           }
         }
       }
@@ -26113,6 +30655,12 @@
             "state" : "translated",
             "value" : "Ви вирішуєте, з якими пристроями ви ділитесь якими файлами. Це також означає, що розробники застосунку не можуть допомогти вам отримати доступ або відновити втрачені файли."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您决定与哪些设备共享哪些文件。这也意味着应用程序开发者无法帮助您访问或恢复任何丢失的文件。"
+          }
         }
       }
     },
@@ -26147,6 +30695,12 @@
             "state" : "translated",
             "value" : "Ваші пристрої, ваші дані, ваша відповідальність"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您的设备，您的数据，您的责任"
+          }
         }
       }
     },
@@ -26180,6 +30734,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Пошук файлу..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索文件..."
           }
         }
       }

--- a/localize.mjs
+++ b/localize.mjs
@@ -5,7 +5,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import { readFile, writeFile } from "node:fs/promises";
 
-const LOCALES = ["nl", "de", "it", "es", "uk"];
+const LOCALES = ["nl", "de", "it", "es", "uk", "zh-Hans"];
 const OPENAI_KEY = process.env.OPENAI_KEY;
 const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_MODEL = "gpt-4o-2024-08-06";


### PR DESCRIPTION
- Generated the zh-Hans translation using `localize.mjs`.
- Manually polished a few translations for accuracy.
