### PR TITLE
Fix typo in bookmark alert message

### DIFF
--- a/Sushitrain/BrowserView.swift
+++ b/Sushitrain/BrowserView.swift
@@ -261,7 +261,7 @@ struct BrowserView: View {
 			}
 		#else
 			.alert(
-				"This location has been added to your bookmarks. Bookmarked locations can be accessed quickly from the start page, or by long-tapping the app icon om the home screen.",
+				"This location has been added to your bookmarks. Bookmarked locations can be accessed quickly from the start page, or by long-tapping the app icon on the home screen.",
 				isPresented: $showNewBookmarkInfo
 			) {
 				Button("OK") {}


### PR DESCRIPTION
Just spotted a small typo

Let me know if the footer has to be in the message and I’ll force push it in. Can’t do atm because on a phone

Signed-off-by: Tom Jenkinson <tom@tjenkinson.me>