### PR TITLE
Sync videos and live photos in photo folders

### DIFF
--- a/Docs/photo-fs.md
+++ b/Docs/photo-fs.md
@@ -7,9 +7,10 @@ Synctrain provides two mechanisms for synchronizing photos from the iOS photo li
   selective synchronization the exported photos can be deselected again once other devices have received the photos. The
   downside of this approach is that as long as other devices have not synchronized the photos yet, they take up disk space.
 - The **photo folder** feature exposes one or more photo albums from the system photo library to Syncthing as if they
-  existed in an actual (send-only) folder. Photos are never exported to disk, but instead read from the system photo library
-  directly. This also means that whenever a photo is deleted from the system photo library, it will disappear from the
-  synchronized folder as well.
+  existed in an actual (send-only) folder. Photos, videos and live photos can be exposed. Still images are read from the
+  system photo library directly and never written to disk; videos and live photos are exported to a temporary on-disk cache
+  on demand (and evicted automatically). Whenever an item is deleted from the system photo library, it will disappear from
+  the synchronized folder as well.
 
 The photo folder feature is implemented by tricking Syncthing into thinking that it is accessing a folder containing
 the photos as files, which is not actually the case. Instead our code 'simulates' a file system, and the photo files are
@@ -49,15 +50,16 @@ object from and to JSON format in the folder's `path`.
 
 ## Limitations
 
-- Photo folders currently cannot be used to synchronize live photos or videos. This is because the file system interface
-  is based around blocking calls, whereas exporting videos is an asynchronous operation on the Swift side. If you need to
-  export videos and/or live photos, use the _photo back-up_ feature instead.
+- Videos and live photos are supported, but are exported on demand to a temporary cache (`Caches/photofs-media/`) the first
+  time they are read, because the file system interface is based around blocking calls. The cache is bounded by a
+  least-recently-used eviction and is reused across rebuilds (keyed by asset identity and modification date), but scanning a
+  large video still requires reading its full exported copy.
 - Photo folders can currently only be synchronized in 'send only' mode, as the underlying virtual file system implementation
   does not implement writing operations.
-- The current implementation assumes that exporting photos from the library is not an expensive operation (it will ask for
-  the current version of a photo asset, without any re-encoding or resizing). This may not always be the case (i.e. when
-  photos are stored in iCloud). As photo export happens each time a virtual 'photo file' is accessed this may degrade
-  performance significantly.
+- Exporting media from the library can be expensive. Still images are re-exported each time a virtual 'photo file' is
+  accessed (without re-encoding or resizing); videos and live photos are exported once and then served from the cache.
+  Assets stored only in iCloud are skipped unless the per-folder "download from iCloud" option is enabled, in which case
+  they are downloaded on access (which may be slow and use mobile data).
 - The virtual photo files will have their creation and last modified date set to the creation date provided by iOS for that
   asset.
 - When a photo is deleted from a photo album, the deletion will of course be propagated to other peers. Due to this the

--- a/Sushitrain/PhotoBackup.swift
+++ b/Sushitrain/PhotoBackup.swift
@@ -807,7 +807,8 @@ enum PhotoBackupProgress {
 }
 
 extension PHAsset {
-	fileprivate var primaryResource: PHAssetResource? {
+	// Used by both the photo back-up and the photo folder (PhotoFS) to export the original media.
+	var primaryResource: PHAssetResource? {
 		let types: Set<PHAssetResourceType>
 
 		switch mediaType {
@@ -890,17 +891,38 @@ extension PHAsset {
 		return components
 	}
 
+	// Subdirectory components (relative to the asset's base directory) for the paired video of a live
+	// photo: the same components as the still image, plus a "Live" subdirectory for the type-grouped
+	// folder structures. Shared between the photo back-up and photo folders (PhotoFS).
+	func livePhotoSubdirectories(structure: PhotoBackupFolderStructure, timeZone: PhotoBackupTimeZone) -> [String] {
+		var components = self.subdirectoriesInFolder(structure: structure, timeZone: timeZone)
+		switch structure {
+		case .byDateAndType, .byType, .byDateComponentAndType, .byYearAndType, .byYearMonthAndType, .byYearDashMonthAndType:
+			components.append("Live")
+		case .byDate, .singleFolder, .singleFolderDatePrefixed, .byDateComponent, .byYear, .byYearMonth, .byYearDashMonth:
+			break
+		}
+		return components
+	}
+
+	// File name for the paired video of a live photo, either replacing (IMG_1337.MOV) or appending
+	// (IMG_1337.HEIC.MOV) the .MOV extension. Shared between the photo back-up and photo folders.
+	func livePhotoFileName(structure: PhotoBackupFolderStructure, replaceExtension: Bool) -> String {
+		let base = self.fileNameInFolder(structure: structure)
+		if replaceExtension {
+			return (base as NSString).deletingPathExtension + ".MOV"
+		}
+		return base + ".MOV"
+	}
+
 	fileprivate func livePhotoDirectoryPathInFolder(
 		structure: PhotoBackupFolderStructure, subdirectoryPath: EntryPath, timeZone: PhotoBackupTimeZone
 	)
 		-> EntryPath
 	{
-		var path = self.directoryPathInFolder(structure: structure, subdirectoryPath: subdirectoryPath, timeZone: timeZone)
-		switch structure {
-		case .byDateAndType, .byType, .byDateComponentAndType, .byYearAndType, .byYearMonthAndType, .byYearDashMonthAndType:
-			path = path.appending("Live", isDirectory: true)
-		case .byDate, .singleFolder, .singleFolderDatePrefixed, .byDateComponent, .byYear, .byYearMonth, .byYearDashMonth:
-			break
+		var path = subdirectoryPath
+		for component in self.livePhotoSubdirectories(structure: structure, timeZone: timeZone) {
+			path = path.appending(component, isDirectory: true)
 		}
 		return path
 	}
@@ -909,20 +931,10 @@ extension PHAsset {
 		structure: PhotoBackupFolderStructure, subdirectoryPath: EntryPath, timeZone: PhotoBackupTimeZone,
 		replaceExtension: Bool
 	) -> EntryPath {
-		var fileName = self.fileNameInFolder(structure: structure)
-		if replaceExtension {
-			// Replace file extension: IMG_1337.MOV
-			fileName = (fileName as NSString).deletingPathExtension + ".MOV"
-		}
-		else {
-			// Append file extension: IMG_1337.HEIC.MOV
-			fileName += ".MOV"
-		}
-
 		return self.livePhotoDirectoryPathInFolder(
 			structure: structure, subdirectoryPath: subdirectoryPath, timeZone: timeZone
 		)
-		.appending(fileName, isDirectory: false)
+		.appending(self.livePhotoFileName(structure: structure, replaceExtension: replaceExtension), isDirectory: false)
 	}
 
 	func fileNameInFolder(structure: PhotoBackupFolderStructure) -> String {

--- a/Sushitrain/PhotoFS.swift
+++ b/Sushitrain/PhotoFS.swift
@@ -69,6 +69,18 @@ private class CustomFSEntry: NSObject, SushitrainCustomFileEntryProtocol {
 	func bytes(_ ret: UnsafeMutablePointer<Int>?) throws {
 		throw CustomFSError.notAFile
 	}
+
+	// By default entries are fully loaded into memory once (through data()). Large entries
+	// (e.g. videos) override streams() to return true and implement read(at:length:) so they
+	// can be read lazily in ranges without loading the whole file into memory.
+	func streams() -> Bool {
+		return false
+	}
+
+	func read(at offset: Int64, length: Int) throws -> Data {
+		// Only invoked for streaming entries; non-streaming entries are served from data().
+		throw CustomFSError.notAFile
+	}
 }
 
 private protocol CustomFSDirectory {
@@ -151,10 +163,12 @@ private class StaticCustomFSEntry: CustomFSEntry {
 
 private class PhotoFSAssetEntry: CustomFSEntry {
 	let asset: PHAsset
+	private let allowNetworkAccess: Bool
 	private var cachedSize: Int? = nil
 
-	init(_ name: String, asset: PHAsset) {
+	init(_ name: String, asset: PHAsset, allowNetworkAccess: Bool) {
 		self.asset = asset
+		self.allowNetworkAccess = allowNetworkAccess
 		super.init(name)
 	}
 
@@ -181,7 +195,7 @@ private class PhotoFSAssetEntry: CustomFSEntry {
 		options.isSynchronous = true
 		options.resizeMode = .none
 		options.deliveryMode = .highQualityFormat
-		options.isNetworkAccessAllowed = false
+		options.isNetworkAccessAllowed = self.allowNetworkAccess
 		options.allowSecondaryDegradedImage = false
 		options.version = .current
 
@@ -207,6 +221,243 @@ private class PhotoFSAssetEntry: CustomFSEntry {
 			return exported
 		}
 		throw PhotoFSError.assetUnavailable
+	}
+}
+
+// Base for file system entries whose contents are exported once to a cached file on disk and then
+// read lazily in ranges through read(at:length:). Unlike images (small enough to be loaded into
+// memory through data()), this avoids ever holding a whole video in memory, which would get the app
+// killed by iOS, especially in the background. Subclasses provide which asset resource to export.
+private class PhotoFSExportedMediaEntry: CustomFSEntry {
+	fileprivate let asset: PHAsset
+	private let allowNetworkAccess: Bool
+	private let exportLock = NSLock()
+	private var exportedURL: URL? = nil
+	private var cachedSize: Int? = nil
+
+	init(_ name: String, asset: PHAsset, allowNetworkAccess: Bool) {
+		self.asset = asset
+		self.allowNetworkAccess = allowNetworkAccess
+		super.init(name)
+	}
+
+	override func isDir() -> Bool {
+		return false
+	}
+
+	// Read lazily in ranges instead of being preloaded into memory.
+	override func streams() -> Bool {
+		return true
+	}
+
+	override func modifiedTime() -> Int64 {
+		return Int64(asset.creationDate?.timeIntervalSince1970 ?? 0.0)
+	}
+
+	// The asset resource to export to disk. Overridden by subclasses (e.g. the original video, or the
+	// paired video of a live photo). Returning nil makes the entry unavailable.
+	fileprivate func resourceToExport() -> PHAssetResource? {
+		return nil
+	}
+
+	// Discriminator added to the cache file name so different exports of the same asset (e.g. a video
+	// versus a live photo's paired video) never collide.
+	fileprivate var cacheDiscriminator: String {
+		return ""
+	}
+
+	override func bytes(_ ret: UnsafeMutablePointer<Int>?) throws {
+		let url = try self.ensureExported()
+		self.exportLock.lock()
+		defer { self.exportLock.unlock() }
+		if let s = self.cachedSize {
+			ret?.pointee = s
+			return
+		}
+		let attrs = try FileManager.default.attributesOfItem(atPath: url.path(percentEncoded: false))
+		let size = (attrs[.size] as? Int) ?? 0
+		self.cachedSize = size
+		ret?.pointee = size
+	}
+
+	override func read(at offset: Int64, length: Int) throws -> Data {
+		let url = try self.ensureExported()
+		let handle = try FileHandle(forReadingFrom: url)
+		defer { try? handle.close() }
+		try handle.seek(toOffset: UInt64(max(0, offset)))
+		return try handle.read(upToCount: length) ?? Data()
+	}
+
+	// Exports the asset resource to a cached file exactly once. Subsequent calls (including across tree
+	// rebuilds, since the cache is keyed by asset identity and modification date) reuse the existing
+	// file. Guarded by a lock so concurrent Syncthing reads never export twice.
+	private func ensureExported() throws -> URL {
+		self.exportLock.lock()
+		defer { self.exportLock.unlock() }
+
+		if let url = self.exportedURL, FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) {
+			return url
+		}
+
+		guard let resource = self.resourceToExport() else {
+			throw PhotoFSError.assetUnavailable
+		}
+
+		let cacheDir = try PhotoFSExportedMediaEntry.cacheDirectory()
+		let destURL = cacheDir.appendingPathComponent(
+			PhotoFSExportedMediaEntry.cacheKey(for: asset, resource: resource, discriminator: self.cacheDiscriminator))
+
+		// Reuse a previously exported file if it is still present. Touch its modification date so the
+		// cache eviction (which is LRU by modification date) treats it as recently used.
+		if FileManager.default.fileExists(atPath: destURL.path(percentEncoded: false)) {
+			try? FileManager.default.setAttributes(
+				[.modificationDate: Date()], ofItemAtPath: destURL.path(percentEncoded: false))
+			self.exportedURL = destURL
+			return destURL
+		}
+
+		// Export to a unique temporary file first, then move it into place, so an interrupted export
+		// can never be mistaken for a complete cache entry. writeData streams to disk, so the whole
+		// file is never held in memory.
+		let tmpURL = cacheDir.appendingPathComponent("tmp-" + UUID().uuidString)
+		let options = PHAssetResourceRequestOptions()
+		options.isNetworkAccessAllowed = self.allowNetworkAccess  // download iCloud-only assets if enabled
+
+		let semaphore = DispatchSemaphore(value: 0)
+		var exportError: Error? = nil
+		PHAssetResourceManager.default().writeData(for: resource, toFile: tmpURL, options: options) { error in
+			exportError = error
+			semaphore.signal()
+		}
+
+		// Safety net: never block a Syncthing worker thread indefinitely (e.g. on a stuck iCloud fetch).
+		if semaphore.wait(timeout: .now() + 120.0) == .timedOut {
+			try? FileManager.default.removeItem(at: tmpURL)
+			Log.warn("Timed out exporting media '\(asset.localIdentifier)'")
+			throw PhotoFSError.assetUnavailable
+		}
+
+		if let exportError = exportError {
+			try? FileManager.default.removeItem(at: tmpURL)
+			Log.warn("Could not export media '\(asset.localIdentifier)': \(exportError.localizedDescription)")
+			throw PhotoFSError.assetUnavailable
+		}
+
+		try? FileManager.default.removeItem(at: destURL)
+		try FileManager.default.moveItem(at: tmpURL, to: destURL)
+		self.exportedURL = destURL
+
+		// Keep the on-disk cache bounded. pruneCache() returns immediately (work runs on its own queue).
+		PhotoFSExportedMediaEntry.pruneCache()
+		return destURL
+	}
+
+	private static func cacheDirectory() throws -> URL {
+		let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+		let dir = base.appendingPathComponent("photofs-media", isDirectory: true)
+		try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+		return dir
+	}
+
+	private static func cacheKey(for asset: PHAsset, resource: PHAssetResource, discriminator: String) -> String {
+		let id = asset.localIdentifier.replacingOccurrences(of: "/", with: "_")
+		let mod = Int(asset.modificationDate?.timeIntervalSince1970 ?? 0.0)
+		let ext = (resource.originalFilename as NSString).pathExtension
+		let disc = discriminator.isEmpty ? "" : "-\(discriminator)"
+		return "\(id)\(disc)-\(mod).\(ext.isEmpty ? "mov" : ext)"
+	}
+
+	// Soft cap on the on-disk export cache. A single asset larger than this is still kept (it is needed
+	// to serve the file); iOS may additionally purge the Caches directory under storage pressure.
+	private static let maxCacheBytes: Int64 = 2 * 1024 * 1024 * 1024  // 2 GB
+
+	// Files used (exported or touched) within this window are never evicted, to avoid deleting a file
+	// that is currently being read, and to drop only genuinely orphaned temporary files.
+	private static let evictionGrace: TimeInterval = 5 * 60
+
+	// Serial queue that serializes cache pruning so concurrent exports never prune at the same time.
+	private static let pruneQueue = DispatchQueue(label: "nl.t-shaped.sushitrain.photofs.prune", qos: .utility)
+
+	// Asynchronously bounds the export cache (LRU by modification date) and removes orphaned temporary
+	// files. Returns immediately; the work runs on a dedicated serial queue. A file deleted while still
+	// being read either keeps serving its open handle or is transparently re-exported.
+	fileprivate static func pruneCache() {
+		PhotoFSExportedMediaEntry.pruneQueue.async {
+			PhotoFSExportedMediaEntry.pruneCacheNow()
+		}
+	}
+
+	private static func pruneCacheNow() {
+		guard let dir = try? PhotoFSExportedMediaEntry.cacheDirectory() else { return }
+		let keys: Set<URLResourceKey> = [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey]
+		guard
+			let urls = try? FileManager.default.contentsOfDirectory(
+				at: dir, includingPropertiesForKeys: Array(keys))
+		else { return }
+
+		let now = Date()
+		var items: [(url: URL, size: Int64, modified: Date)] = []
+		var total: Int64 = 0
+
+		for url in urls {
+			guard let values = try? url.resourceValues(forKeys: keys), values.isRegularFile == true else {
+				continue
+			}
+			let size = Int64(values.fileSize ?? 0)
+			let modified = values.contentModificationDate ?? .distantPast
+
+			// Drop orphaned temporary files left behind by interrupted or crashed exports.
+			if url.lastPathComponent.hasPrefix("tmp-") {
+				if now.timeIntervalSince(modified) > Self.evictionGrace {
+					try? FileManager.default.removeItem(at: url)
+				}
+				continue
+			}
+
+			items.append((url: url, size: size, modified: modified))
+			total += size
+		}
+
+		if total <= Self.maxCacheBytes {
+			return
+		}
+
+		for item in items.sorted(by: { $0.modified < $1.modified }) {
+			if total <= Self.maxCacheBytes {
+				break
+			}
+			// Never evict very recently used files (likely in active use).
+			if now.timeIntervalSince(item.modified) <= Self.evictionGrace {
+				continue
+			}
+			if (try? FileManager.default.removeItem(at: item.url)) != nil {
+				total -= item.size
+			}
+		}
+	}
+}
+
+// A single video asset, exported as its original video resource.
+private final class PhotoFSVideoEntry: PhotoFSExportedMediaEntry {
+	fileprivate override func resourceToExport() -> PHAssetResource? {
+		return asset.primaryResource
+	}
+
+	fileprivate override var cacheDiscriminator: String {
+		return "video"
+	}
+}
+
+// The paired video of a live photo, exported as a separate .MOV entry alongside the still image.
+private final class PhotoFSLivePhotoEntry: PhotoFSExportedMediaEntry {
+	fileprivate override func resourceToExport() -> PHAssetResource? {
+		let resources = PHAssetResource.assetResources(for: asset)
+		return resources.first(where: { $0.type == .fullSizePairedVideo })
+			?? resources.first(where: { $0.type == .pairedVideo })
+	}
+
+	fileprivate override var cacheDiscriminator: String {
+		return "live"
 	}
 }
 
@@ -251,13 +502,33 @@ private class PhotoFSAlbumEntry: CustomFSEntry {
 			// Faux directory used to give folderStructure.place a CustomFSDirectory interface for the root directory
 			let fauxRoot = StaticCustomFSDirectory("", children: [])
 			let structure = self.config.folderStructure ?? .singleFolder
+			let timeZone = self.config.timeZone ?? .specific(timeZone: TimeZone.gmt.identifier)
+			let categories = self.config.effectiveCategories
+			let replaceExtension = self.config.livePhotoReplaceExtension ?? false
+			let allowNetworkAccess = self.config.effectiveAllowNetworkAccess
 
 			// Enumerate relevant assets
 			let assets = PHAsset.fetchAssets(in: album, options: nil)
 			assets.enumerateObjects { asset, index, stop in
-				if asset.mediaType == .image {
-					structure.place(
-						asset: asset, root: fauxRoot, timeZone: self.config.timeZone ?? .specific(timeZone: TimeZone.gmt.identifier))
+				switch asset.mediaType {
+				case .image:
+					if categories.contains(.photo) {
+						structure.place(
+							asset: asset, root: fauxRoot, timeZone: timeZone, allowNetworkAccess: allowNetworkAccess)
+					}
+					// A live photo is an image asset with a paired video, exposed as a separate .MOV entry.
+					if categories.contains(.livePhoto) && asset.mediaSubtypes.contains(.photoLive) {
+						structure.placeLivePhoto(
+							asset: asset, root: fauxRoot, timeZone: timeZone, replaceExtension: replaceExtension,
+							allowNetworkAccess: allowNetworkAccess)
+					}
+				case .video:
+					if categories.contains(.video) {
+						structure.place(
+							asset: asset, root: fauxRoot, timeZone: timeZone, allowNetworkAccess: allowNetworkAccess)
+					}
+				default:
+					break
 				}
 			}
 
@@ -290,6 +561,27 @@ struct PhotoFSAlbumConfiguration: Codable, Equatable {
 
 	var timeZone: PhotoBackupTimeZone? = nil
 
+	// Media types to expose. Optional/nil for backward compatibility with configurations written
+	// by older versions, which only ever synchronized photos.
+	var categories: Set<PhotoBackupCategory>? = nil
+
+	// Whether the paired video of a live photo replaces (IMG.MOV) or appends (IMG.HEIC.MOV) the .MOV
+	// extension. Optional for backward compatibility; defaults to appending.
+	var livePhotoReplaceExtension: Bool? = nil
+
+	// Whether assets stored only in iCloud may be downloaded on access. When false (the default),
+	// iCloud-only assets are skipped rather than downloaded. Optional for backward compatibility.
+	var allowNetworkAccess: Bool? = nil
+
+	var effectiveAllowNetworkAccess: Bool {
+		return self.allowNetworkAccess ?? false
+	}
+
+	// The effective set of media types, defaulting to photos only (the historical behavior).
+	var effectiveCategories: Set<PhotoBackupCategory> {
+		return self.categories ?? [.photo]
+	}
+
 	var isValid: Bool {
 		return !self.albumID.isEmpty
 	}
@@ -300,7 +592,9 @@ struct PhotoFSConfiguration: Codable, Equatable {
 }
 
 extension PhotoBackupFolderStructure {
-	fileprivate func place(asset: PHAsset, root: CustomFSDirectory, timeZone: PhotoBackupTimeZone) {
+	fileprivate func place(
+		asset: PHAsset, root: CustomFSDirectory, timeZone: PhotoBackupTimeZone, allowNetworkAccess: Bool
+	) {
 		let translatedFileName = asset.fileNameInFolder(structure: self)
 		let subdirs = asset.subdirectoriesInFolder(structure: self, timeZone: timeZone)
 
@@ -309,7 +603,30 @@ extension PhotoBackupFolderStructure {
 			dir = dir.getOrCreateSubdirectory(dirName)
 		}
 
-		dir.place(PhotoFSAssetEntry(translatedFileName, asset: asset))
+		switch asset.mediaType {
+		case .video:
+			// Videos are read lazily in ranges from a cached export (see PhotoFSVideoEntry).
+			dir.place(PhotoFSVideoEntry(translatedFileName, asset: asset, allowNetworkAccess: allowNetworkAccess))
+		default:
+			dir.place(PhotoFSAssetEntry(translatedFileName, asset: asset, allowNetworkAccess: allowNetworkAccess))
+		}
+	}
+
+	// Places the paired video of a live photo as a separate .MOV entry, using the same naming as the
+	// photo back-up (optionally in a "Live" subdirectory for type-grouped folder structures).
+	fileprivate func placeLivePhoto(
+		asset: PHAsset, root: CustomFSDirectory, timeZone: PhotoBackupTimeZone, replaceExtension: Bool,
+		allowNetworkAccess: Bool
+	) {
+		let fileName = asset.livePhotoFileName(structure: self, replaceExtension: replaceExtension)
+		let subdirs = asset.livePhotoSubdirectories(structure: self, timeZone: timeZone)
+
+		var dir = root
+		for dirName in subdirs {
+			dir = dir.getOrCreateSubdirectory(dirName)
+		}
+
+		dir.place(PhotoFSLivePhotoEntry(fileName, asset: asset, allowNetworkAccess: allowNetworkAccess))
 	}
 }
 
@@ -389,6 +706,9 @@ extension PhotoFS: SushitrainCustomFilesystemTypeProtocol {
 		Task.detached {
 			// Apparently the PHPhotoLibrary.shared().register call can take a while, so we really don't want to do this on the main thread
 			PhotoFSLibraryObserver.shared.registerForNotifications()
+
+			// Opportunistically bound the export cache and clean up orphaned temporary files on load.
+			PhotoFSExportedMediaEntry.pruneCache()
 		}
 
 		return folderRoot

--- a/Sushitrain/PhotoFS.swift
+++ b/Sushitrain/PhotoFS.swift
@@ -36,7 +36,9 @@ enum PhotoFSError: LocalizedError {
 }
 
 private class CustomFSEntry: NSObject, SushitrainCustomFileEntryProtocol {
-	let entryName: String
+	// Mutable so a containing directory can rename an entry to resolve a name collision (see
+	// StaticCustomFSDirectory.place).
+	var entryName: String
 
 	internal init(_ name: String, _ children: [CustomFSEntry]? = nil) {
 		self.entryName = name
@@ -90,10 +92,13 @@ private protocol CustomFSDirectory {
 
 private class StaticCustomFSDirectory: CustomFSEntry {
 	var children: [CustomFSEntry]
+	// Names already present among the children, kept in sync with `children` for O(1) collision checks.
+	fileprivate var usedNames: Set<String>
 	let modTime: Date
 
 	init(_ name: String, children: [CustomFSEntry]) {
 		self.children = children
+		self.usedNames = Set(children.map { $0.name() })
 		self.modTime = Date()
 		super.init(name)
 	}
@@ -129,12 +134,36 @@ extension StaticCustomFSDirectory: CustomFSDirectory {
 			// Create
 			let subDir = StaticCustomFSDirectory(name, children: [])
 			self.children.append(subDir)
+			self.usedNames.insert(name)
 			return subDir
 		}
 	}
 
 	func place(_ entry: CustomFSEntry) {
+		// Two assets can map to the same file name (e.g. re-imported photos, or a live photo's .MOV
+		// colliding with a real video). Rename on collision so every child in a directory is unique;
+		// otherwise the bridge would only ever resolve the first one and list the name twice.
+		if self.usedNames.contains(entry.name()) {
+			entry.entryName = self.uniqueName(for: entry.name())
+		}
+		self.usedNames.insert(entry.name())
 		self.children.append(entry)
+	}
+
+	// Returns `name` if free, otherwise inserts a numeric suffix before the extension (IMG.MOV ->
+	// IMG-1.MOV) until an unused name is found.
+	private func uniqueName(for name: String) -> String {
+		let ns = name as NSString
+		let base = ns.deletingPathExtension
+		let ext = ns.pathExtension
+		var i = 1
+		while true {
+			let candidate = ext.isEmpty ? "\(base)-\(i)" : "\(base)-\(i).\(ext)"
+			if !self.usedNames.contains(candidate) {
+				return candidate
+			}
+			i += 1
+		}
 	}
 }
 
@@ -234,6 +263,7 @@ private class PhotoFSExportedMediaEntry: CustomFSEntry {
 	private let exportLock = NSLock()
 	private var exportedURL: URL? = nil
 	private var cachedSize: Int? = nil
+	private var lastTouched: Date? = nil
 
 	init(_ name: String, asset: PHAsset, allowNetworkAccess: Bool) {
 		self.asset = asset
@@ -267,17 +297,57 @@ private class PhotoFSExportedMediaEntry: CustomFSEntry {
 	}
 
 	override func bytes(_ ret: UnsafeMutablePointer<Int>?) throws {
-		let url = try self.ensureExported()
+		// Fast path: size already known in memory.
 		self.exportLock.lock()
-		defer { self.exportLock.unlock() }
-		if let s = self.cachedSize {
+		let cached = self.cachedSize
+		self.exportLock.unlock()
+		if let s = cached {
 			ret?.pointee = s
 			return
 		}
+
+		// Avoid exporting the whole file just to report its size (Syncthing calls this on every scan):
+		// use the persisted size sidecar if present, even when the media file itself has been evicted.
+		let key = self.currentCacheKey()
+		if let key = key, let s = PhotoFSExportedMediaEntry.persistedSize(forKey: key) {
+			self.exportLock.lock()
+			self.cachedSize = s
+			self.exportLock.unlock()
+			ret?.pointee = s
+			return
+		}
+
+		// Unknown size: export, measure, and persist it so future scans don't need to export again.
+		let url = try self.ensureExported()
 		let attrs = try FileManager.default.attributesOfItem(atPath: url.path(percentEncoded: false))
 		let size = (attrs[.size] as? Int) ?? 0
+		self.exportLock.lock()
 		self.cachedSize = size
+		self.exportLock.unlock()
+		if let key = key {
+			PhotoFSExportedMediaEntry.persistSize(size, forKey: key)
+		}
 		ret?.pointee = size
+	}
+
+	// The cache key for this entry's export, or nil if no resource is available. Does not export.
+	private func currentCacheKey() -> String? {
+		guard let resource = self.resourceToExport() else { return nil }
+		return PhotoFSExportedMediaEntry.cacheKey(for: asset, resource: resource, discriminator: self.cacheDiscriminator)
+	}
+
+	// Refresh the cached file's modification date (LRU marker), at most once a minute. Caller holds exportLock.
+	private func touchIfNeeded(_ url: URL) {
+		if let last = self.lastTouched, Date().timeIntervalSince(last) < 60.0 {
+			return
+		}
+		self.touch(url)
+	}
+
+	private func touch(_ url: URL) {
+		try? FileManager.default.setAttributes(
+			[.modificationDate: Date()], ofItemAtPath: url.path(percentEncoded: false))
+		self.lastTouched = Date()
 	}
 
 	override func read(at offset: Int64, length: Int) throws -> Data {
@@ -296,6 +366,8 @@ private class PhotoFSExportedMediaEntry: CustomFSEntry {
 		defer { self.exportLock.unlock() }
 
 		if let url = self.exportedURL, FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) {
+			// Keep an actively-read file out of the LRU eviction window during a long transfer.
+			self.touchIfNeeded(url)
 			return url
 		}
 
@@ -310,8 +382,7 @@ private class PhotoFSExportedMediaEntry: CustomFSEntry {
 		// Reuse a previously exported file if it is still present. Touch its modification date so the
 		// cache eviction (which is LRU by modification date) treats it as recently used.
 		if FileManager.default.fileExists(atPath: destURL.path(percentEncoded: false)) {
-			try? FileManager.default.setAttributes(
-				[.modificationDate: Date()], ofItemAtPath: destURL.path(percentEncoded: false))
+			self.touch(destURL)
 			self.exportedURL = destURL
 			return destURL
 		}
@@ -346,6 +417,7 @@ private class PhotoFSExportedMediaEntry: CustomFSEntry {
 		try? FileManager.default.removeItem(at: destURL)
 		try FileManager.default.moveItem(at: tmpURL, to: destURL)
 		self.exportedURL = destURL
+		self.lastTouched = Date()  // freshly written
 
 		// Keep the on-disk cache bounded. pruneCache() returns immediately (work runs on its own queue).
 		PhotoFSExportedMediaEntry.pruneCache()
@@ -365,6 +437,31 @@ private class PhotoFSExportedMediaEntry: CustomFSEntry {
 		let ext = (resource.originalFilename as NSString).pathExtension
 		let disc = discriminator.isEmpty ? "" : "-\(discriminator)"
 		return "\(id)\(disc)-\(mod).\(ext.isEmpty ? "mov" : ext)"
+	}
+
+	// Persisted exported-size sidecars (`<cacheKey>.size`). They are tiny, deterministic for a given
+	// cache key (same original resource bytes), and outlive the media file so a scan can report a size
+	// without re-exporting an evicted file. A missing/corrupt sidecar simply falls back to exporting.
+	private static func sizeSidecarURL(forKey key: String) throws -> URL {
+		return try cacheDirectory().appendingPathComponent(key + ".size")
+	}
+
+	private static func persistedSize(forKey key: String) -> Int? {
+		guard let url = try? sizeSidecarURL(forKey: key),
+			let data = try? Data(contentsOf: url),
+			let text = String(data: data, encoding: .utf8),
+			let size = Int(text.trimmingCharacters(in: .whitespacesAndNewlines))
+		else {
+			return nil
+		}
+		return size
+	}
+
+	private static func persistSize(_ size: Int, forKey key: String) {
+		guard let url = try? sizeSidecarURL(forKey: key), let data = "\(size)".data(using: .utf8) else {
+			return
+		}
+		try? data.write(to: url, options: .atomic)
 	}
 
 	// Soft cap on the on-disk export cache. A single asset larger than this is still kept (it is needed
@@ -405,6 +502,11 @@ private class PhotoFSExportedMediaEntry: CustomFSEntry {
 			}
 			let size = Int64(values.fileSize ?? 0)
 			let modified = values.contentModificationDate ?? .distantPast
+
+			// Size sidecars are tiny and must outlive the media they describe: never count or evict them.
+			if url.pathExtension == "size" {
+				continue
+			}
 
 			// Drop orphaned temporary files left behind by interrupted or crashed exports.
 			if url.lastPathComponent.hasPrefix("tmp-") {
@@ -467,6 +569,9 @@ private class PhotoFSAlbumEntry: CustomFSEntry {
 	private let config: PhotoFSAlbumConfiguration
 	private var lastUpdate: Date? = nil
 	private var lastChangeCounter = -1
+	// Serializes update()/children access: the bridge calls childCount()/child(at:) from concurrent
+	// Syncthing worker threads, and update() replaces `children` wholesale on library changes.
+	private let lock = NSLock()
 
 	init(_ name: String, config: PhotoFSAlbumConfiguration) throws {
 		self.config = config
@@ -543,13 +648,23 @@ private class PhotoFSAlbumEntry: CustomFSEntry {
 	}
 
 	override func child(at index: Int) throws -> any SushitrainCustomFileEntryProtocol {
+		self.lock.lock()
+		defer { self.lock.unlock() }
 		try self.update()
-		return self.children![index]
+		let children = self.children ?? []
+		// The library may have changed (and the tree shrunk) between the caller's childCount() and this
+		// call; guard against an out-of-range index rather than crashing.
+		guard index >= 0 && index < children.count else {
+			throw CustomFSError.notAFile
+		}
+		return children[index]
 	}
 
 	override func childCount(_ ret: UnsafeMutablePointer<Int>?) throws {
+		self.lock.lock()
+		defer { self.lock.unlock() }
 		try self.update()
-		ret?.pointee = self.children!.count
+		ret?.pointee = self.children?.count ?? 0
 	}
 }
 

--- a/Sushitrain/PhotoFolderSettingsView.swift
+++ b/Sushitrain/PhotoFolderSettingsView.swift
@@ -255,14 +255,28 @@ private struct PhotoFolderAlbumSettingsView: View {
 			}
 
 			Section {
-				Toggle("Photos", isOn: .constant(true)).disabled(true)
-				Toggle("Live photos", isOn: .constant(false)).disabled(true)
-				Toggle("Videos", isOn: .constant(false)).disabled(true)
+				Toggle("Photos", isOn: self.categoryBinding(.photo))
+				Toggle("Live photos", isOn: self.categoryBinding(.livePhoto))
+				Toggle("Videos", isOn: self.categoryBinding(.video))
 			} header: {
 				Text("Save the following media types")
+			}
+
+			if self.config.effectiveCategories.contains(.livePhoto) {
+				Section {
+					Picker("Live photo file extension", selection: self.livePhotoReplaceExtensionBinding) {
+						Text(".HEIC.MOV").tag(false)
+						Text(".MOV").tag(true)
+					}
+					.pickerStyle(.menu)
+				}
+			}
+
+			Section {
+				Toggle("Download from iCloud if needed", isOn: self.allowNetworkAccessBinding)
 			} footer: {
 				Text(
-					"Photo folders can only synchronize photos in the current version of the app. To save videos and/or live photos, use the photo back-up function, available in the settings screen."
+					"When enabled, photos and videos that are only stored in iCloud are downloaded when synchronized. This may use mobile data and can be slow. When disabled, iCloud-only items are skipped."
 				)
 			}
 		}
@@ -273,6 +287,33 @@ private struct PhotoFolderAlbumSettingsView: View {
 			authorizationStatus = PHPhotoLibrary.authorizationStatus()
 		}
 		.navigationTitle(dirName.isEmpty ? "Add album" : "Settings for '\(dirName)'")
+	}
+
+	private var livePhotoReplaceExtensionBinding: Binding<Bool> {
+		Binding(
+			get: { self.config.livePhotoReplaceExtension ?? false },
+			set: { self.config.livePhotoReplaceExtension = $0 })
+	}
+
+	private var allowNetworkAccessBinding: Binding<Bool> {
+		Binding(
+			get: { self.config.effectiveAllowNetworkAccess },
+			set: { self.config.allowNetworkAccess = $0 })
+	}
+
+	private func categoryBinding(_ category: PhotoBackupCategory) -> Binding<Bool> {
+		Binding(
+			get: { self.config.effectiveCategories.contains(category) },
+			set: { isOn in
+				var categories = self.config.effectiveCategories
+				if isOn {
+					categories.insert(category)
+				}
+				else {
+					categories.remove(category)
+				}
+				self.config.categories = categories
+			})
 	}
 
 	private func requestAuthorization() {

--- a/SushitrainCore/src/customfs.go
+++ b/SushitrainCore/src/customfs.go
@@ -27,7 +27,8 @@ type customFilesystem struct {
 type customFile struct {
 	info     *customFileWrapper
 	position int64
-	data     []byte
+	data     []byte // preloaded contents for non-streaming entries; nil when streaming
+	stream   bool   // when true, contents are pulled lazily through info.file.ReadAt
 	mut      *sync.Mutex
 }
 
@@ -45,6 +46,18 @@ type CustomFileEntry interface {
 	Data() ([]byte, error)
 	ModifiedTime() int64
 	Bytes() (int, error)
+
+	// Streams reports whether this entry should be read lazily in ranges (through ReadAt)
+	// instead of being fully loaded into memory through Data(). Large media such as videos
+	// return true to avoid loading the entire file into memory (which would get the app
+	// killed on iOS). Small entries (images, static files) return false and keep the
+	// original behavior of being preloaded once on open.
+	Streams() bool
+
+	// ReadAt returns up to length bytes starting at offset. It is only called for entries
+	// that return true from Streams(). Returning fewer bytes than requested is allowed; an
+	// empty result signals end-of-file.
+	ReadAt(offset int64, length int) ([]byte, error)
 }
 
 type CustomFilesystemType interface {
@@ -89,12 +102,18 @@ func (p *customFilesystem) OpenFile(name string, flags int, mode fs.FileMode) (f
 		return nil, err
 	}
 
-	var data []byte
-	if data, err = item.file.Data(); err != nil {
-		return nil, err
+	cf := &customFile{info: item, mut: &sync.Mutex{}, stream: item.file.Streams()}
+
+	// Non-streaming entries (images, small static files) are fully loaded into memory once and
+	// served from that buffer. Streaming entries (e.g. videos) are read lazily in ranges to
+	// avoid loading the whole file into memory.
+	if !cf.stream {
+		if cf.data, err = item.file.Data(); err != nil {
+			return nil, err
+		}
 	}
 
-	return &customFile{info: item, data: data, mut: &sync.Mutex{}}, nil
+	return cf, nil
 }
 
 func (p *customFilesystem) Glob(pattern string) ([]string, error) {
@@ -311,6 +330,27 @@ func (cf *customFile) Read(p []byte) (n int, err error) {
 func (cf *customFile) ReadAt(p []byte, offset int64) (n int, err error) {
 	cf.mut.Lock()
 	defer cf.mut.Unlock()
+
+	if cf.stream {
+		size := cf.info.Size()
+		if size >= 0 && offset >= size {
+			return 0, io.EOF
+		}
+
+		// Fill p by pulling ranges from the Swift side until it is full or we reach EOF.
+		for n < len(p) {
+			chunk, e := cf.info.file.ReadAt(offset+int64(n), len(p)-n)
+			if e != nil {
+				return n, e
+			}
+			if len(chunk) == 0 {
+				break // reached end of file
+			}
+			n += copy(p[n:], chunk)
+		}
+		cf.position = offset + int64(n)
+		return n, nil
+	}
 
 	if offset >= int64(len(cf.data)) {
 		return 0, io.EOF

--- a/SushitrainCore/src/customfs.go
+++ b/SushitrainCore/src/customfs.go
@@ -323,14 +323,22 @@ func (p *customFile) Name() string {
 }
 
 func (cf *customFile) Read(p []byte) (n int, err error) {
-	n, err = cf.ReadAt(p, cf.position)
+	cf.mut.Lock()
+	defer cf.mut.Unlock()
+	n, err = cf.readAtLocked(p, cf.position)
+	cf.position += int64(n)
 	return
 }
 
+// ReadAt is position-independent (io.ReaderAt): it must not affect nor be affected by the seek offset.
 func (cf *customFile) ReadAt(p []byte, offset int64) (n int, err error) {
 	cf.mut.Lock()
 	defer cf.mut.Unlock()
+	return cf.readAtLocked(p, offset)
+}
 
+// readAtLocked performs a read at offset without touching the seek position. The caller must hold mut.
+func (cf *customFile) readAtLocked(p []byte, offset int64) (n int, err error) {
 	if cf.stream {
 		size := cf.info.Size()
 		if size >= 0 && offset >= size {
@@ -348,7 +356,6 @@ func (cf *customFile) ReadAt(p []byte, offset int64) (n int, err error) {
 			}
 			n += copy(p[n:], chunk)
 		}
-		cf.position = offset + int64(n)
 		return n, nil
 	}
 
@@ -357,7 +364,6 @@ func (cf *customFile) ReadAt(p []byte, offset int64) (n int, err error) {
 	}
 
 	n = copy(p, cf.data[int(offset):])
-	cf.position = offset + int64(n)
 	return n, nil
 }
 

--- a/SushitrainCore/src/customfs_test.go
+++ b/SushitrainCore/src/customfs_test.go
@@ -152,6 +152,38 @@ func TestCustomFilesystemStreamingChunkedRead(t *testing.T) {
 	}
 }
 
+// ReadAt is io.ReaderAt and must not move the sequential read position: a random ReadAt followed by
+// a full sequential read must still return the whole content from the start.
+func TestCustomFilesystemReadAtKeepsPosition(t *testing.T) {
+	content := []byte("0123456789abcdefghijABCDEFGHIJ") // 30 bytes
+	for _, streaming := range []bool{true, false} {
+		file := &fakeEntry{entryName: "f.bin", content: content, streaming: streaming}
+		cfs := newTestFS(file)
+		fh, err := cfs.Open("f.bin")
+		if err != nil {
+			t.Fatalf("streaming=%v open: %v", streaming, err)
+		}
+
+		ra, ok := fh.(io.ReaderAt)
+		if !ok {
+			t.Fatal("custom file does not implement io.ReaderAt")
+		}
+		buf := make([]byte, 4)
+		if _, err := ra.ReadAt(buf, 20); err != nil && err != io.EOF {
+			t.Fatalf("streaming=%v readAt: %v", streaming, err)
+		}
+
+		got, err := io.ReadAll(fh)
+		if err != nil {
+			t.Fatalf("streaming=%v read all: %v", streaming, err)
+		}
+		if !bytes.Equal(got, content) {
+			t.Fatalf("streaming=%v: read = %q, want full content %q", streaming, got, content)
+		}
+		fh.Close()
+	}
+}
+
 func TestCustomFilesystemNonStreamingRead(t *testing.T) {
 	content := []byte("hello world")
 	file := &fakeEntry{entryName: "photo.jpg", content: content, streaming: false}

--- a/SushitrainCore/src/customfs_test.go
+++ b/SushitrainCore/src/customfs_test.go
@@ -1,0 +1,183 @@
+// Copyright (C) 2025 Tommy van der Vorst
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+package sushitrain
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/fs"
+)
+
+// fakeEntry is a minimal in-memory CustomFileEntry used to exercise the custom filesystem
+// read paths (both the legacy preloaded path and the streaming/range-read path).
+type fakeEntry struct {
+	entryName string
+	dir       bool
+	children  []CustomFileEntry
+	content   []byte
+	streaming bool
+	maxChunk  int // when > 0, ReadAt returns at most this many bytes per call
+
+	dataCalls int // number of times Data() was called
+	readCalls int // number of times ReadAt() was called
+}
+
+func (f *fakeEntry) Name() string { return f.entryName }
+func (f *fakeEntry) IsDir() bool  { return f.dir }
+func (f *fakeEntry) ChildCount() (int, error) { return len(f.children), nil }
+func (f *fakeEntry) ChildAt(index int) (CustomFileEntry, error) { return f.children[index], nil }
+func (f *fakeEntry) ModifiedTime() int64 { return 0 }
+func (f *fakeEntry) Bytes() (int, error) { return len(f.content), nil }
+func (f *fakeEntry) Streams() bool { return f.streaming }
+
+func (f *fakeEntry) Data() ([]byte, error) {
+	f.dataCalls++
+	return f.content, nil
+}
+
+func (f *fakeEntry) ReadAt(offset int64, length int) ([]byte, error) {
+	f.readCalls++
+	if offset >= int64(len(f.content)) {
+		return nil, nil // EOF
+	}
+	if f.maxChunk > 0 && length > f.maxChunk {
+		length = f.maxChunk
+	}
+	end := offset + int64(length)
+	if end > int64(len(f.content)) {
+		end = int64(len(f.content))
+	}
+	return f.content[offset:end], nil
+}
+
+func newTestFS(file *fakeEntry) *customFilesystem {
+	root := &fakeEntry{entryName: "", dir: true, children: []CustomFileEntry{file}}
+	return &customFilesystem{fsType: fs.FilesystemType("test"), uri: "test", root: root}
+}
+
+func TestCustomFilesystemStreamingRead(t *testing.T) {
+	content := []byte("0123456789abcdefghijABCDEFGHIJ") // 30 bytes
+	file := &fakeEntry{entryName: "video.mov", content: content, streaming: true}
+	cfs := newTestFS(file)
+
+	// Stat reports the correct size without preloading the content.
+	info, err := cfs.Stat("video.mov")
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Size() != int64(len(content)) {
+		t.Fatalf("size = %d, want %d", info.Size(), len(content))
+	}
+
+	fh, err := cfs.Open("video.mov")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer fh.Close()
+
+	// Streaming entries must not be preloaded through Data().
+	if file.dataCalls != 0 {
+		t.Fatalf("Data() called %d times for streaming entry, want 0", file.dataCalls)
+	}
+
+	// A sequential read returns the full content.
+	got, err := io.ReadAll(fh)
+	if err != nil {
+		t.Fatalf("read all: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("read = %q, want %q", got, content)
+	}
+
+	// ReadAt at an offset returns the right slice.
+	ra, ok := fh.(io.ReaderAt)
+	if !ok {
+		t.Fatal("custom file does not implement io.ReaderAt")
+	}
+	buf := make([]byte, 5)
+	n, err := ra.ReadAt(buf, 10)
+	if err != nil && err != io.EOF {
+		t.Fatalf("readAt: %v", err)
+	}
+	if n != 5 || !bytes.Equal(buf, content[10:15]) {
+		t.Fatalf("readAt = %q (n=%d), want %q", buf[:n], n, content[10:15])
+	}
+
+	// Reading at or past the end signals EOF.
+	if n, err := ra.ReadAt(buf, int64(len(content))); err != io.EOF || n != 0 {
+		t.Fatalf("readAt at EOF = (%d, %v), want (0, EOF)", n, err)
+	}
+}
+
+// A streaming entry whose ReadAt returns only a few bytes per call (as a video export served in
+// small pieces might) must still fill a larger read buffer correctly, with no gaps or duplication.
+func TestCustomFilesystemStreamingChunkedRead(t *testing.T) {
+	content := []byte("0123456789abcdefghijABCDEFGHIJ") // 30 bytes
+	file := &fakeEntry{entryName: "video.mov", content: content, streaming: true, maxChunk: 4}
+	cfs := newTestFS(file)
+
+	fh, err := cfs.Open("video.mov")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer fh.Close()
+
+	ra, ok := fh.(io.ReaderAt)
+	if !ok {
+		t.Fatal("custom file does not implement io.ReaderAt")
+	}
+
+	// A full sequential read must reassemble the 4-byte chunks to the exact content.
+	got, err := io.ReadAll(fh)
+	if err != nil {
+		t.Fatalf("read all: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("read = %q, want %q", got, content)
+	}
+
+	// Reading a 16-byte window in a single ReadAt must also loop over 4-byte chunks to fill it.
+	buf := make([]byte, 16)
+	n, err := ra.ReadAt(buf, 7)
+	if err != nil && err != io.EOF {
+		t.Fatalf("readAt: %v", err)
+	}
+	if n != 16 || !bytes.Equal(buf, content[7:23]) {
+		t.Fatalf("chunked readAt = %q (n=%d), want %q", buf[:n], n, content[7:23])
+	}
+}
+
+func TestCustomFilesystemNonStreamingRead(t *testing.T) {
+	content := []byte("hello world")
+	file := &fakeEntry{entryName: "photo.jpg", content: content, streaming: false}
+	cfs := newTestFS(file)
+
+	fh, err := cfs.Open("photo.jpg")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer fh.Close()
+
+	// Non-streaming entries are preloaded exactly once through Data().
+	if file.dataCalls != 1 {
+		t.Fatalf("Data() called %d times, want 1", file.dataCalls)
+	}
+
+	got, err := io.ReadAll(fh)
+	if err != nil {
+		t.Fatalf("read all: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("read = %q, want %q", got, content)
+	}
+
+	// The streaming path must never be used for non-streaming entries.
+	if file.readCalls != 0 {
+		t.Fatalf("ReadAt() called %d times for non-streaming entry, want 0", file.readCalls)
+	}
+}


### PR DESCRIPTION
## What

Photo folders (the `sushitrain.photos.v1` virtual filesystem) so far only
exposed still images. This adds, selectable per album:

- **Videos** and **live photos** (the paired video) as synchronizable files
- An option to **download iCloud-only assets** on access (off by default)

This makes photo folders a full alternative to the photo back-up for libraries
with videos and live photos, without permanently copying anything to disk.

## How

The custom filesystem bridge loaded each file fully into memory via `Data()` on
open, fine for images, not for videos. An opt-in streaming path was added to
`CustomFileEntry`:

- `Streams()` marks an entry as read lazily; `ReadAt(offset, length)` serves
  bounded ranges. Non-streaming entries (images, static files) keep the exact
  previous behavior.
- Videos and live-photo videos are exported once to a cached file under
  `Caches/photofs-media/` (the original asset resource, so block hashes stay
  stable) and read in ranges via `FileHandle`,  the whole file is never held in
  memory.
- The export cache is bounded by an LRU eviction (by modification date, with a
  grace window) that also removes orphaned temporary files.
- Live-photo naming reuses the photo back-up path logic, factored into shared
  helpers (behavior-preserving for the back-up).

Photo folders remain send-only.

## Testing

- `customfs_test.go` covers the streaming, chunked-fill and non-streaming read
  paths: `go test -tags noassets ./src` passes.

> The documentation, the code comments and the PR is made with AI but not the code (I wrote that sentence myself haha)
